### PR TITLE
We can now keep non-whitelisted tags' children by unwrapping them.

### DIFF
--- a/HtmlSanitizer.Tests/Tests.cs
+++ b/HtmlSanitizer.Tests/Tests.cs
@@ -2122,6 +2122,17 @@ rl(javascript:alert(""foo""))'>";
             var html = @"<div>Hallo</div>";
             Assert.That(sanitizer.Sanitize(html), Is.EqualTo(@"<div class=""test"">Hallo<b>Test</b></div>").IgnoreCase);
         }
+
+        [Test]
+        public void UnwrapNonWhitelistedTagsProcessTest()
+        {
+            const string html = @"<b>some <b>bold </b><i>content</i></b>";
+
+            var allowedTags = new[] { "i" };
+            var sanitizer = new HtmlSanitizer(allowedTags: allowedTags);
+
+            Assert.That(sanitizer.Sanitize(html, removeNonWhitelistedTags: false), Is.EqualTo(@"some bold <i>content</i>").IgnoreCase);
+        }
     }
 }
 


### PR DESCRIPTION
In some cases I need to keep the html and/or text inside non-whitelisted tags. For that reason, instead of removing these DOM elements, I only want to unwrap the content inside.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mganss/htmlsanitizer/25)
<!-- Reviewable:end -->
