### PR TITLE
Added DefaultHtmlEncoder property to allow specifying the HtmlEncoder…

### DIFF
--- a/HtmlSanitizer.Tests/Tests.cs
+++ b/HtmlSanitizer.Tests/Tests.cs
@@ -1,4 +1,4 @@
-using CsQuery;
+﻿using CsQuery;
 using Ganss.Text;
 using NUnit.Framework;
 using System;
@@ -2297,12 +2297,12 @@ rl(javascript:alert(""foo""))'>";
         }
 
         [Test]
-        public void DefaultHtmlEncoder_ShouldBeOverridable()
+        public void HtmlEncoder_ShouldBeOverridable()
         {
             // Arrange
             var s = new HtmlSanitizer
             {
-                DefaultHtmlEncoder = HtmlEncoders.Minimum
+                HtmlEncoder = HtmlEncoders.Minimum
             };
 
             // Act

--- a/HtmlSanitizer.Tests/Tests.cs
+++ b/HtmlSanitizer.Tests/Tests.cs
@@ -2295,6 +2295,21 @@ rl(javascript:alert(""foo""))'>";
             var expected = "<span style='background-image: url(\"/api/users/defaultAvatar\")'></span>";
             Assert.That(actual, Is.EqualTo(expected).IgnoreCase);
         }
+
+        [Test]
+        public void DefaultHtmlEncoder_ShouldBeOverridable()
+        {
+            // Arrange
+            var s = new HtmlSanitizer
+            {
+                DefaultHtmlEncoder = HtmlEncoders.Minimum
+            };
+
+            // Act
+
+            Assert.That(s.Sanitize("é"), Is.EqualTo("é"));
+            Assert.That(s.Sanitize("€"), Is.EqualTo("€"));
+        }
     }
 }
 

--- a/HtmlSanitizer/HtmlSanitizer.cs
+++ b/HtmlSanitizer/HtmlSanitizer.cs
@@ -196,7 +196,7 @@ namespace Ganss.XSS
         /// <value>
         /// The HtmlEncoder implementation.
         /// </value>
-        public IHtmlEncoder DefaultHtmlEncoder { get; set; }
+        public IHtmlEncoder HtmlEncoder { get; set; }
 
         /// <summary>
         /// The default allowed CSS properties.
@@ -381,11 +381,11 @@ namespace Ganss.XSS
                 }
             }
 
-            if (DefaultHtmlEncoder == null)
-                DefaultHtmlEncoder = HtmlEncoders.Default;
+            if (HtmlEncoder == null)
+                HtmlEncoder = HtmlEncoders.Default;
 
             if (outputFormatter == null)
-                outputFormatter = new FormatDefault(DomRenderingOptions.RemoveComments | DomRenderingOptions.QuoteAllAttributes, DefaultHtmlEncoder);
+                outputFormatter = new FormatDefault(DomRenderingOptions.RemoveComments | DomRenderingOptions.QuoteAllAttributes, HtmlEncoder);
 
             var output = dom.Render(outputFormatter);
 

--- a/HtmlSanitizer/HtmlSanitizer.cs
+++ b/HtmlSanitizer/HtmlSanitizer.cs
@@ -191,6 +191,14 @@ namespace Ganss.XSS
         public ISet<string> AllowedCssProperties { get; private set; }
 
         /// <summary>
+        /// Gets or sets the default HTML encoder that will be used to encode final output.
+        /// </summary>
+        /// <value>
+        /// The HtmlEncoder implementation.
+        /// </value>
+        public IHtmlEncoder DefaultHtmlEncoder { get; set; }
+
+        /// <summary>
         /// The default allowed CSS properties.
         /// </summary>
         public static readonly ISet<string> DefaultAllowedCssProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
@@ -373,8 +381,11 @@ namespace Ganss.XSS
                 }
             }
 
+            if (DefaultHtmlEncoder == null)
+                DefaultHtmlEncoder = HtmlEncoders.Default;
+
             if (outputFormatter == null)
-                outputFormatter = new FormatDefault(DomRenderingOptions.RemoveComments | DomRenderingOptions.QuoteAllAttributes, HtmlEncoders.Default);
+                outputFormatter = new FormatDefault(DomRenderingOptions.RemoveComments | DomRenderingOptions.QuoteAllAttributes, DefaultHtmlEncoder);
 
             var output = dom.Render(outputFormatter);
 


### PR DESCRIPTION
… to use when creating a new instance of HtmlSanitizer.

By default `HtmlEncoders.Default` was used, to override it you had to specify a new Formatter on each `.Sanitize` call.