### PR TITLE
Added remove reason to removal events

### DIFF
--- a/HtmlSanitizer/EventArgs.cs
+++ b/HtmlSanitizer/EventArgs.cs
@@ -60,6 +60,14 @@ namespace Ganss.XSS
         /// The tag.
         /// </value>
         public IElement Tag { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reason why the tag will be removed
+        /// </summary>
+        /// <value>
+        /// The reason.
+        /// </value>
+        public RemoveReason Reason { get; set; }
     }
 
     /// <summary>
@@ -74,6 +82,14 @@ namespace Ganss.XSS
         /// The attribute.
         /// </value>
         public IAttr Attribute { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reason why the attribute will be removed
+        /// </summary>
+        /// <value>
+        /// The reason.
+        /// </value>
+        public RemoveReason Reason { get; set; }
     }
 
     /// <summary>
@@ -88,6 +104,14 @@ namespace Ganss.XSS
         /// The style.
         /// </value>
         public ICssProperty Style { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reason why the style will be removed
+        /// </summary>
+        /// <value>
+        /// The reason.
+        /// </value>
+        public RemoveReason Reason { get; set; }
     }
 
 }

--- a/HtmlSanitizer/HtmlSanitizer.cs
+++ b/HtmlSanitizer/HtmlSanitizer.cs
@@ -455,13 +455,13 @@ namespace Ganss.XSS
                 var key = DecodeCss(style.Name);
                 var val = DecodeCss(style.Value);
 
-                if (!AllowedCssProperties.Contains(key) || DisallowCssPropertyValue.IsMatch(val))
+                if (!AllowedCssProperties.Contains(key))
                 {
                     removeStyles.Add(new Tuple<ICssProperty, RemoveReason>(style, RemoveReason.NotAllowedStyle));
                     continue;
                 }
 
-                if(CssExpression.IsMatch(val))
+                if(CssExpression.IsMatch(val) || DisallowCssPropertyValue.IsMatch(val))
                 {
                     removeStyles.Add(new Tuple<ICssProperty, RemoveReason>(style, RemoveReason.NotAllowedValue));
                     continue;

--- a/HtmlSanitizer/HtmlSanitizer.csproj
+++ b/HtmlSanitizer/HtmlSanitizer.csproj
@@ -67,6 +67,7 @@
     <Compile Include="HtmlSanitizer.cs" />
     <Compile Include="IHtmlSanitizer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RemoveReason.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="HtmlSanitizer.snk" />

--- a/HtmlSanitizer/RemoveReason.cs
+++ b/HtmlSanitizer/RemoveReason.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ganss.XSS
+{
+    /// <summary>
+    /// List of reasons why something was identified to get removed from the HTML
+    /// </summary>
+    public enum RemoveReason
+    {
+        /// <summary>
+        /// Tag is not allowed
+        /// </summary>
+        NotAllowedTag,
+        /// <summary>
+        /// Attribute is not allowed
+        /// </summary>
+        NotAllowedAttribute,
+        /// <summary>
+        /// Style is not allowed
+        /// </summary>
+        NotAllowedStyle,
+        /// <summary>
+        /// Value is a not allowed or harmful url
+        /// </summary>
+        NotAllowedUrlValue,
+        /// <summary>
+        /// Value is not allowed or harmful
+        /// </summary>
+        NotAllowedValue,
+    }
+}


### PR DESCRIPTION
I have added an additional information to the removal events so that consumer get more details why something will be removed. So it is easier to decide if a removal should be canceled or do some additional stuff when parts of the HTML are removed.