### PR TITLE
Added Tag attributes to event args

### DIFF
--- a/HtmlSanitizer.Tests/Tests.cs
+++ b/HtmlSanitizer.Tests/Tests.cs
@@ -2066,12 +2066,30 @@ rl(javascript:alert(""foo""))'>";
         }
 
         [Test]
+        public void RemovingAttributeEventTagTest()
+        {
+            var sanitizer = new HtmlSanitizer();
+            sanitizer.RemovingAttribute += (s, e) => Assert.That(e.Tag, Is.InstanceOf<IHtmlDivElement>());
+            var html = @"<div alt=""alt"" onclick=""test"" onload=""test""></div>";
+            sanitizer.Sanitize(html);
+        }
+
+        [Test]
         public void RemovingStyleEventTest()
         {
             var sanitizer = new HtmlSanitizer();
             sanitizer.RemovingStyle += (s, e) => e.Cancel = e.Style.Name == "test";
             var html = @"<div style=""background: 0; test: xyz; bad: bad;""></div>";
             Assert.That(sanitizer.Sanitize(html), Is.EqualTo(@"<div style=""background: 0; test: xyz""></div>").IgnoreCase);
+        }
+
+        [Test]
+        public void RemovingStyleEventTagTest()
+        {
+            var sanitizer = new HtmlSanitizer();
+            sanitizer.RemovingStyle += (s, e) => Assert.That(e.Tag, Is.InstanceOf<IHtmlDivElement>());
+            var html = @"<div style=""background: 0; test: xyz; bad: bad;""></div>";
+            sanitizer.Sanitize(html);
         }
 
         [Test]

--- a/HtmlSanitizer/EventArgs.cs
+++ b/HtmlSanitizer/EventArgs.cs
@@ -76,6 +76,14 @@ namespace Ganss.XSS
     public class RemovingAttributeEventArgs : CancelEventArgs
     {
         /// <summary>
+        /// The tag containing the attribute to be removed.
+        /// </summary>
+        /// <value>
+        /// The tag.
+        /// </value>
+        public IElement Tag { get; set; }
+
+        /// <summary>
         /// Gets or sets the attribute to be removed.
         /// </summary>
         /// <value>
@@ -97,6 +105,14 @@ namespace Ganss.XSS
     /// </summary>
     public class RemovingStyleEventArgs : CancelEventArgs
     {
+        /// <summary>
+        /// The tag containing the style to be removed.
+        /// </summary>
+        /// <value>
+        /// The tag.
+        /// </value>
+        public IElement Tag { get; set; }
+
         /// <summary>
         /// Gets or sets the style to be removed.
         /// </summary>

--- a/HtmlSanitizer/HtmlSanitizer.cs
+++ b/HtmlSanitizer/HtmlSanitizer.cs
@@ -490,7 +490,7 @@ namespace Ganss.XSS
 
             foreach (var style in removeStyles)
             {
-                RemoveStyle(styles, style.Item1, style.Item2);
+                RemoveStyle(element, styles, style.Item1, style.Item2);
             }
 
             foreach (var style in setStyles)
@@ -595,7 +595,7 @@ namespace Ganss.XSS
         /// <param name="reason">reason why to be removed</param>
         private void RemoveAttribute(IElement tag, IAttr attribute, RemoveReason reason)
         {
-            var e = new RemovingAttributeEventArgs { Attribute = attribute, Reason = reason };
+            var e = new RemovingAttributeEventArgs { Tag = tag, Attribute = attribute, Reason = reason };
             OnRemovingAttribute(e);
             if (!e.Cancel) tag.RemoveAttribute(attribute.Name);
         }
@@ -603,12 +603,13 @@ namespace Ganss.XSS
         /// <summary>
         /// Remove a style from the document.
         /// </summary>
+        /// <param name="tag">tag where the style belongs</param>
         /// <param name="styles">collection where the style to belongs</param>
         /// <param name="style">to be removed</param>
         /// <param name="reason">reason why to be removed</param>
-        private void RemoveStyle(ICssStyleDeclaration styles, ICssProperty style, RemoveReason reason)
+        private void RemoveStyle(IElement tag, ICssStyleDeclaration styles, ICssProperty style, RemoveReason reason)
         {
-            var e = new RemovingStyleEventArgs { Style = style, Reason = reason };
+            var e = new RemovingStyleEventArgs { Tag = tag, Style = style, Reason = reason };
             OnRemovingStyle(e);
             if (!e.Cancel) styles.RemoveProperty(style.Name);
         }


### PR DESCRIPTION
The `RemovingAttributeEventArgs` and `RemovingStyleEventArgs` classes do not currently indicate which tag from the DOM is being affected. By knowing the affected tag I can make better decisions about whether or not to `Cancel()` the deletion.