### PR TITLE
Add dotnet core support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,6 @@ cov-int.zip
 coverity.zip
 
 .vs/
+
+# dotnet
+*.lock.json

--- a/HtmlSanitizer/HtmlSanitizer.cs
+++ b/HtmlSanitizer/HtmlSanitizer.cs
@@ -728,7 +728,11 @@ namespace Ganss.XSS
             {
                 return uri.IsAbsoluteUri ? uri.AbsoluteUri : uri.GetComponents(UriComponents.SerializationInfoString, UriFormat.UriEscaped);
             }
+#if NETSTANDARD
+            catch (Exception)
+#else
             catch (UriFormatException)
+#endif
             {
                 return null;
             }

--- a/HtmlSanitizer/HtmlSanitizer.xproj
+++ b/HtmlSanitizer/HtmlSanitizer.xproj
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>ccdb0c26-d683-4943-b5d8-ac07116461e5</ProjectGuid>
+    <RootNamespace>Ganss.XSS</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/HtmlSanitizer/Properties/AssemblyInfo.cs
+++ b/HtmlSanitizer/Properties/AssemblyInfo.cs
@@ -14,6 +14,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
+#if !NETSTANDARD
+
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
@@ -21,6 +23,8 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("16af04e9-e712-417e-b749-c8d10148dda9")]
+
+#endif
 
 // assembly version information will be reset by AppVeyor
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/HtmlSanitizer/project.json
+++ b/HtmlSanitizer/project.json
@@ -1,0 +1,48 @@
+{
+  "version": "3.3",
+  "title": "HtmlSanitizer",
+  "description": "Cleans HTML from constructs that can be used for cross site scripting (XSS)",
+  "authors": [ "Michael Ganss" ],
+  "copyright": "Copyright 2013-2016 Michael Ganss",
+  "packOptions": {
+    "projectUrl": "https://github.com/mganss/HtmlSanitizer",
+    "tags": [ "xss", "anti", "antixss", "html", "security" ],
+    "licenseUrl": "https://raw.github.com/mganss/HtmlSanitizer/master/LICENSE.md",
+    "repository": {
+      "type": "git",
+      "url": "git://github.com/mganss/HtmlSanitizer"
+    }
+  },
+  "dependencies": {
+    "AngleSharp": "0.9.6"
+  },
+  "frameworks": {
+    "net45": {
+      "frameworkAssemblies": {
+        "System.Globalization": "",
+        "System.IO": "",
+        "System.Runtime": ""
+      }
+    },
+    "netstandard1.3": {
+      "imports": [ "dotnet" ],
+      "buildOptions": {
+        "define": [
+          "NETSTANDARD"
+        ]
+      },
+      "dependencies": {
+        "System.Collections": "4.0.11-rc3-23909",
+        "System.ComponentModel": "4.0.1-rc2-24027",
+        "System.Diagnostics.Debug": "4.0.11-rc3-23909",
+        "System.Globalization": "4.0.11-rc3-23909",
+        "System.IO": "4.1.0-rc3-23909",
+        "System.Linq": "4.1.0-rc3-23909",
+        "System.Runtime": "4.1.0-rc3-23909",
+        "System.Runtime.Extensions": "4.1.0-rc3-23909",
+        "System.Text.RegularExpressions": "4.0.12-rc3-23909",
+        "System.Threading": "4.0.11-rc3-23909"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds project.json and necessary #if regions to build for netstandard 1.3.

I am not sure how you want to configure AppVeyor to build this. The new way to create the nuget package that targets both .NET 4.5 and .NET CORE is to do the following:
```text
cd src\HtmlSanitizer
dotnet restore
dotnet build -c Release   # Not actually necessary as pack does this
dotnet pack -c Release    # You can also specify output directory for .nupkg
```

Other repositories that do dotnet core:
* https://github.com/JamesNK/Newtonsoft.Json
* https://github.com/SapientGuardian/mysql-connector-net-netstandard