### PR TITLE
CSS class whitelisting

### DIFF
--- a/src/HtmlSanitizer/EventArgs.cs
+++ b/src/HtmlSanitizer/EventArgs.cs
@@ -162,4 +162,34 @@ namespace Ganss.XSS
         /// </value>
         public IComment Comment { get; set; }
     }
+
+    /// <summary>
+    /// Provides data for the <see cref="HtmlSanitizer.RemovingCssClass"/> event.
+    /// </summary>
+    public class RemovingCssClassEventArgs : CancelEventArgs
+    {
+        /// <summary>
+        /// Gets or sets the tag containing the CSS class to be removed.
+        /// </summary>
+        /// <value>
+        /// The tag.
+        /// </value>
+        public IElement Tag { get; set; }
+
+        /// <summary>
+        /// Gets or sets the CSS class to be removed.
+        /// </summary>
+        /// <value>
+        /// The CSS class.
+        /// </value>
+        public string CssClass { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reason why the CSS class will be removed.
+        /// </summary>
+        /// <value>
+        /// The reason.
+        /// </value>
+        public RemoveReason Reason { get; set; }
+    }
 }

--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -55,10 +55,10 @@ namespace Ganss.XSS
         /// Initializes a new instance of the <see cref="HtmlSanitizer"/> class.
         /// </summary>
         /// <param name="allowedTags">The allowed tag names such as "a" and "div". When <c>null</c>, uses <see cref="DefaultAllowedTags"/></param>
-        /// <param name="allowedSchemes">The allowed HTTP schemes such as "http" and "https". When <c>null</c>,  uses <see cref="DefaultAllowedSchemes"/></param>
+        /// <param name="allowedSchemes">The allowed HTTP schemes such as "http" and "https". When <c>null</c>, uses <see cref="DefaultAllowedSchemes"/></param>
         /// <param name="allowedAttributes">The allowed HTML attributes such as "href" and "alt". When <c>null</c>, uses <see cref="DefaultAllowedAttributes"/></param>
-        /// <param name="uriAttributes">the HTML attributes that can contain a URI such as "href". When <c>null</c>, uses <see cref="DefaultUriAttributes"/></param>
-        /// <param name="allowedCssProperties">the allowed CSS properties such as "font" and "margin". When <c>null</c>, uses <see cref="DefaultAllowedCssProperties"/></param>
+        /// <param name="uriAttributes">The HTML attributes that can contain a URI such as "href". When <c>null</c>, uses <see cref="DefaultUriAttributes"/></param>
+        /// <param name="allowedCssProperties">The allowed CSS properties such as "font" and "margin". When <c>null</c>, uses <see cref="DefaultAllowedCssProperties"/></param>
         public HtmlSanitizer(IEnumerable<string> allowedTags = null, IEnumerable<string> allowedSchemes = null,
             IEnumerable<string> allowedAttributes = null, IEnumerable<string> uriAttributes = null, IEnumerable<string> allowedCssProperties = null)
         {

--- a/src/HtmlSanitizer/IHtmlSanitizer.cs
+++ b/src/HtmlSanitizer/IHtmlSanitizer.cs
@@ -64,6 +64,13 @@ namespace Ganss.XSS
         /// </value>
         Regex DisallowCssPropertyValue { get; set; }
 
+        /// Gets or sets the allowed CSS classes.
+        /// </summary>
+        /// <value>
+        /// The allowed CSS classes.
+        /// </value>
+        ISet<string> AllowedCssClasses { get; }
+
         /// <summary>
         /// Occurs for every node after sanitizing.
         /// </summary>
@@ -83,6 +90,11 @@ namespace Ganss.XSS
         /// Occurs before a style is removed.
         /// </summary>
         event EventHandler<RemovingStyleEventArgs> RemovingStyle;
+
+        /// <summary>
+        /// Occurs before a CSS class is removed.
+        /// </summary>
+        event EventHandler<RemovingCssClassEventArgs> RemovingCssClass;
 
         /// <summary>
         /// Sanitizes the specified HTML.

--- a/src/HtmlSanitizer/RemoveReason.cs
+++ b/src/HtmlSanitizer/RemoveReason.cs
@@ -25,5 +25,13 @@
         /// Value is not allowed or harmful
         /// </summary>
         NotAllowedValue,
+        /// <summary>
+        /// CSS Class is not allowed
+        /// </summary>
+        NotAllowedCssClass,
+        /// <summary>
+        /// The class attribute is empty
+        /// </summary>
+        ClassAttributeEmpty
     }
 }


### PR DESCRIPTION
Hi, and thanks for the great library!

For my use case, I need to be able to whitelist specific CSS classes. Reading through the issues I found #40, which gives a workaround using events, but that just seems a little untidy to me. I think this update accomplishes this in a way that's consistent with how everything else works. 

This is a breaking change in terms of the interface though; I notice that a few things are missing from `IHtmlSanitizer` anyway (see #92, and seemingly a couple of other members too), so perhaps this could be added in to the next major version?

Cheers, Mark