### PR TITLE
Added methods and event to expose the parsed and cleaned IHtmlDocument.

### DIFF
--- a/src/HtmlSanitizer/EventArgs.cs
+++ b/src/HtmlSanitizer/EventArgs.cs
@@ -10,6 +10,26 @@ namespace Ganss.XSS
     /// <summary>
     /// Provides data for the <see cref="HtmlSanitizer.PostProcessNode"/> event.
     /// </summary>
+    public class PostProcessDomEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets or sets the document.
+        /// </summary>
+        /// <value>
+        /// The document.
+        /// </value>
+        public IHtmlDocument Document { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PostProcessDomEventArgs"/> class.
+        /// </summary>
+        public PostProcessDomEventArgs()
+        { }
+    }
+
+    /// <summary>
+    /// Provides data for the <see cref="HtmlSanitizer.PostProcessNode"/> event.
+    /// </summary>
     public class PostProcessNodeEventArgs : EventArgs
     {
         /// <summary>

--- a/src/HtmlSanitizer/EventArgs.cs
+++ b/src/HtmlSanitizer/EventArgs.cs
@@ -8,7 +8,7 @@ using System.ComponentModel;
 namespace Ganss.XSS
 {
     /// <summary>
-    /// Provides data for the <see cref="HtmlSanitizer.PostProcessNode"/> event.
+    /// Provides data for the <see cref="HtmlSanitizer.PostProcessDom"/> event.
     /// </summary>
     public class PostProcessDomEventArgs : EventArgs
     {

--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -432,18 +432,19 @@ namespace Ganss.XSS
         /// <returns>The sanitized HTML body fragment.</returns>
         public string Sanitize(string html, string baseUrl = "", IMarkupFormatter outputFormatter = null)
         {
-            var dom = SantizeDom(html, baseUrl);
+            var dom = SanitizeDom(html, baseUrl);
             var output = dom.Body.ChildNodes.ToHtml(outputFormatter ?? OutputFormatter);
             return output;
         }
 
+        
         /// <summary>
         /// Sanitizes the specified HTML body fragment. If a document is given, only the body part will be returned.
         /// </summary>
         /// <param name="html">The HTML body fragment to sanitize.</param>
         /// <param name="baseUrl">The base URL relative URLs are resolved against. No resolution if empty.</param>
         /// <returns>The sanitized HTML Document.</returns>
-        public IHtmlDocument SantizeDom(string html, string baseUrl = "")
+        public IHtmlDocument SanitizeDom(string html, string baseUrl = "")
         {
             var parser = HtmlParserFactory();
             var dom = parser.Parse("<html><body></body></html>");

--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -295,6 +295,10 @@ namespace Ganss.XSS
         public ISet<string> AllowedCssClasses { get; private set; }
 
         /// <summary>
+        /// Occurs after sanitizing the document and post processing nodes.
+        /// </summary>
+        public event EventHandler<PostProcessDomEventArgs> PostProcessDom;
+        /// <summary>
         /// Occurs for every node after sanitizing.
         /// </summary>
         public event EventHandler<PostProcessNodeEventArgs> PostProcessNode;
@@ -322,6 +326,15 @@ namespace Ganss.XSS
         /// Occurs before a CSS class is removed.
         /// </summary>
         public event EventHandler<RemovingCssClassEventArgs> RemovingCssClass;
+
+        /// <summary>
+        /// Raises the <see cref="E:PostProcessDom" /> event.
+        /// </summary>
+        /// <param name="e">The <see cref="PostProcessDomEventArgs"/> instance containing the event data.</param>
+        protected virtual void OnPostProcessDom(PostProcessDomEventArgs e)
+        {
+            PostProcessDom?.Invoke(this, e);
+        }
 
         /// <summary>
         /// Raises the <see cref="E:PostProcessNode" /> event.
@@ -419,17 +432,28 @@ namespace Ganss.XSS
         /// <returns>The sanitized HTML body fragment.</returns>
         public string Sanitize(string html, string baseUrl = "", IMarkupFormatter outputFormatter = null)
         {
+            var dom = SantizeDom(html, baseUrl);
+            var output = dom.Body.ChildNodes.ToHtml(outputFormatter ?? OutputFormatter);
+            return output;
+        }
+
+        /// <summary>
+        /// Sanitizes the specified HTML body fragment. If a document is given, only the body part will be returned.
+        /// </summary>
+        /// <param name="html">The HTML body fragment to sanitize.</param>
+        /// <param name="baseUrl">The base URL relative URLs are resolved against. No resolution if empty.</param>
+        /// <returns>The sanitized HTML Document.</returns>
+        public IHtmlDocument SantizeDom(string html, string baseUrl = "")
+        {
             var parser = HtmlParserFactory();
             var dom = parser.Parse("<html><body></body></html>");
             dom.Body.InnerHtml = html;
 
             DoSanitize(dom, dom.Body, baseUrl);
 
-            var output = dom.Body.ChildNodes.ToHtml(outputFormatter ?? OutputFormatter);
-
-            return output;
+            return dom;
         }
-
+        
         /// <summary>
         /// Sanitizes the specified HTML document. Even if only a fragment is given, a whole document will be returned.
         /// </summary>
@@ -629,6 +653,12 @@ namespace Ganss.XSS
                         ((IChildNode)node).Replace(e.ReplacementNodes.ToArray());
                     }
                 }
+            }
+
+            if (PostProcessDom != null)
+            {
+                var e = new PostProcessDomEventArgs { Document = dom };
+                OnPostProcessDom(e);
             }
         }
 

--- a/src/HtmlSanitizer/IHtmlSanitizer.cs
+++ b/src/HtmlSanitizer/IHtmlSanitizer.cs
@@ -1,5 +1,6 @@
 using AngleSharp;
 using AngleSharp.Dom.Css;
+using AngleSharp.Dom.Html;
 using AngleSharp.Parser.Html;
 using System;
 using System.Collections.Generic;
@@ -97,6 +98,11 @@ namespace Ganss.XSS
         ISet<string> AllowedCssClasses { get; }
 
         /// <summary>
+        /// Occurs after sanitizing the document and post processing nodes.
+        /// </summary>
+        event EventHandler<PostProcessDomEventArgs> PostProcessDom;
+
+        /// <summary>
         /// Occurs for every node after sanitizing.
         /// </summary>
         event EventHandler<PostProcessNodeEventArgs> PostProcessNode;
@@ -139,5 +145,22 @@ namespace Ganss.XSS
         /// <param name="outputFormatter">The formatter used to render the DOM. Using the default formatter if null.</param>
         /// <returns>The sanitized HTML.</returns>
         string Sanitize(string html, string baseUrl = "", IMarkupFormatter outputFormatter = null);
+
+        /// <summary>
+        /// Sanitizes the specified HTML body fragment. If a document is given, only the body part will be returned.
+        /// </summary>
+        /// <param name="html">The HTML body fragment to sanitize.</param>
+        /// <param name="baseUrl">The base URL relative URLs are resolved against. No resolution if empty.</param>
+        /// <returns>The sanitized HTML Document.</returns>
+        IHtmlDocument SantizeDom(string html, string baseUrl = "");
+
+        /// <summary>
+        /// Sanitizes the specified HTML document. Even if only a fragment is given, a whole document will be returned.
+        /// </summary>
+        /// <param name="html">The HTML document to sanitize.</param>
+        /// <param name="baseUrl">The base URL relative URLs are resolved against. No resolution if empty.</param>
+        /// <param name="outputFormatter">The formatter used to render the DOM. Using the <see cref="OutputFormatter"/> if null.</param>
+        /// <returns>The sanitized HTML document.</returns>
+        string SanitizeDocument(string html, string baseUrl = "", IMarkupFormatter outputFormatter = null);
     }
 }

--- a/src/HtmlSanitizer/IHtmlSanitizer.cs
+++ b/src/HtmlSanitizer/IHtmlSanitizer.cs
@@ -152,7 +152,7 @@ namespace Ganss.XSS
         /// <param name="html">The HTML body fragment to sanitize.</param>
         /// <param name="baseUrl">The base URL relative URLs are resolved against. No resolution if empty.</param>
         /// <returns>The sanitized HTML Document.</returns>
-        IHtmlDocument SantizeDom(string html, string baseUrl = "");
+        IHtmlDocument SanitizeDom(string html, string baseUrl = "");
 
         /// <summary>
         /// Sanitizes the specified HTML document. Even if only a fragment is given, a whole document will be returned.

--- a/test/HtmlSanitizer.Tests/Tests.cs
+++ b/test/HtmlSanitizer.Tests/Tests.cs
@@ -2166,7 +2166,7 @@ rl(javascript:alert(""foo""))'>";
         }
 
         [Fact]
-        public void PostProcessTest()
+        public void PostProcessNodeTest()
         {
             var sanitizer = new HtmlSanitizer();
             sanitizer.PostProcessNode += (s, e) =>
@@ -2184,6 +2184,22 @@ rl(javascript:alert(""foo""))'>";
             Assert.Equal(@"<div class=""test"">Hallo<b>Test</b></div>", sanitized, ignoreCase: true);
         }
 
+        [Fact]
+        public void PostProcessDomTest()
+        {
+            var sanitizer = new HtmlSanitizer();
+            sanitizer.PostProcessDom += (s, e) => 
+            {
+                var p = e.Document.CreateElement("p");
+                p.TextContent = "World";
+                e.Document.Body.AppendChild(p);
+            };
+
+            var html = @"<div>Hallo</div>";
+            var sanitized = sanitizer.Sanitize(html);
+            Assert.Equal(@"<div>Hallo</div><p>World</p>", sanitized, ignoreCase: true);
+        }
+        
         [Fact]
         public void AutoLinkTest()
         {


### PR DESCRIPTION
Added method SantizeDom that returns the parsed and cleaned IHtmlDocument. This exposes the result for further DOM manipulation without requiring another parse.

Also added a PostProcessDom event that runs after PostProcessNode. This also allows the whole DOM to be further manipulated without executing on every node or re-parsing the document.