### PR TITLE
Add support to NetStandard 2.0.

### DIFF
--- a/src/HtmlSanitizer/HtmlSanitizer.csproj
+++ b/src/HtmlSanitizer/HtmlSanitizer.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>HtmlSanitizer</AssemblyTitle>
     <VersionPrefix>1.0.0-VERSION</VersionPrefix>
     <Authors>Michael Ganss</Authors>
-    <TargetFrameworks>net40;net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.3;netstandard2.0;</TargetFrameworks>
     <AssemblyName>HtmlSanitizer</AssemblyName>
     <AssemblyOriginatorKeyFile>HtmlSanitizer.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/HtmlSanitizer.Tests/HtmlSanitizer.Tests.csproj
+++ b/test/HtmlSanitizer.Tests/HtmlSanitizer.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.0;net452</TargetFrameworks>
     <AssemblyName>HtmlSanitizer.Tests</AssemblyName>
     <PackageId>HtmlSanitizer.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
Please, can you add support to NetStandard2.0 for avoid break dependencies with other libraries?

Follow the changes with all tests running over.

Thank you.
