### PR TITLE
Fixed classcast error in post processing of nodes

### DIFF
--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -629,9 +629,9 @@ namespace Ganss.XSS
         /// <summary>
         /// Removes all comment nodes from a list of nodes.
         /// </summary>
-        /// <param name="context">The element within which to remove comments.</param>
+        /// <param name="context">The node within which to remove comments.</param>
         /// <returns><c>true</c> if any comments were removed; otherwise, <c>false</c>.</returns>
-        private void RemoveComments(IElement context)
+        private void RemoveComments(INode context)
         {
             foreach (var comment in GetAllNodes(context).OfType<IComment>().ToList())
             {
@@ -707,9 +707,9 @@ namespace Ganss.XSS
                 }
             }
 
-            RemoveComments(context as IElement);
+            RemoveComments(context as INode);
 
-            DoPostProcess(dom, context as IElement);
+            DoPostProcess(dom, context as INode);
         }
 
         private void SanitizeStyleSheets(IHtmlDocument dom, string baseUrl)
@@ -775,8 +775,8 @@ namespace Ganss.XSS
         /// Performs post processing on all nodes in the document.
         /// </summary>
         /// <param name="dom">The HTML document.</param>
-        /// <param name="context">The element within which to post process all nodes.</param>
-        private void DoPostProcess(IHtmlDocument dom, IElement context)
+        /// <param name="context">The node within which to post process all nodes.</param>
+        private void DoPostProcess(IHtmlDocument dom, INode context)
         {
             if (PostProcessNode != null)
             {

--- a/test/HtmlSanitizer.Tests/Tests.cs
+++ b/test/HtmlSanitizer.Tests/Tests.cs
@@ -2188,6 +2188,25 @@ rl(javascript:alert(""foo""))'>";
         }
 
         [Fact]
+        public void PostProcessNodeTestUsingDocument()
+        {
+            var sanitizer = new HtmlSanitizer();
+            sanitizer.PostProcessNode += (s, e) =>
+            {
+                if (e.Node is IHtmlDivElement el)
+                {
+                    el.ClassList.Add("test");
+                    var b = e.Document.CreateElement("b");
+                    b.TextContent = "Test";
+                    el.AppendChild(b);
+                }
+            };
+            var html = @"<html><head></head><body><div>Hallo</div></body></html>";
+            var sanitized = sanitizer.SanitizeDocument(html);
+            Assert.Equal(@"<html><head></head><body><div class=""test"">Hallo<b>Test</b></div></body></html>", sanitized, ignoreCase: true);
+        }
+
+        [Fact]
         public void PostProcessDomTest()
         {
             var sanitizer = new HtmlSanitizer();


### PR DESCRIPTION
Hi

Noticed that when you use HtmlSanitizer.SanitizeDocument - the PostProcessNode event isn't called. 
My current workaround is to use PostProcessDom instead and iterate over all the nodes in that event.
Tried to fix the bug with this PR.

---

When you use SanitizeDocument the 'context' parameter of DoPostProcess and RemoveComments is set to be the HTML document itself. The post processing require the context to be an IElement which isn't the case for AngleSharps HtmlDocument. Changed signatures of methods in post processing to use an INode instead. This allows the PostProcessNode event to be called when using SanitizeDocument.