### PR TITLE
Add a new SanitizeDom method taking an IHtmlDocument as a param

### DIFF
--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -579,6 +579,21 @@ namespace Ganss.XSS
         }
 
         /// <summary>
+        /// Sanitizes the specified parsed HTML body fragment.
+        /// The Document Must have been pared with CSS support and the following options enabled
+        /// "IsIncludingUnknownDeclarations", "IsIncludingUnknownRules" and "IsToleratingInvalidSelectors"
+        /// </summary>
+        /// <param name="document">The pared HTML Document.</param>
+        /// <param name="baseUrl">The base URL relative URLs are resolved against. No resolution if empty.</param>
+        /// <returns>The sanitized HTML Document.</returns>
+        public IHtmlDocument SanitizeDom(IHtmlDocument dom, string baseUrl = "")
+        {
+            DoSanitize(dom, dom.Body, baseUrl);
+
+            return dom;
+        }
+
+        /// <summary>
         /// Sanitizes the specified HTML document. Even if only a fragment is given, a whole document will be returned.
         /// </summary>
         /// <param name="html">The HTML document to sanitize.</param>

--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -584,13 +584,21 @@ namespace Ganss.XSS
         /// "IsIncludingUnknownDeclarations", "IsIncludingUnknownRules" and "IsToleratingInvalidSelectors"
         /// </summary>
         /// <param name="document">The pared HTML Document.</param>
+        /// <param name="context">The node within which to sanitize.</param>
         /// <param name="baseUrl">The base URL relative URLs are resolved against. No resolution if empty.</param>
         /// <returns>The sanitized HTML Document.</returns>
-        public IHtmlDocument SanitizeDom(IHtmlDocument dom, string baseUrl = "")
+        public IHtmlDocument SanitizeDom(IHtmlDocument document, IHtmlElement context = null, string baseUrl = "")
         {
-            DoSanitize(dom, dom.Body, baseUrl);
+            if (context == null)
+            {
+                DoSanitize(document, document, baseUrl);
+            }
+            else
+            {
+                DoSanitize(document, context, baseUrl);
+            }
 
-            return dom;
+            return document;
         }
 
         /// <summary>

--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -580,24 +580,17 @@ namespace Ganss.XSS
 
         /// <summary>
         /// Sanitizes the specified parsed HTML body fragment.
-        /// The Document Must have been pared with CSS support and the following options enabled
+        /// The Document Must have been parsed with CSS support and the following options enabled
         /// "IsIncludingUnknownDeclarations", "IsIncludingUnknownRules" and "IsToleratingInvalidSelectors"
         /// </summary>
-        /// <param name="document">The pared HTML Document.</param>
+        /// <param name="document">The parsed HTML Document.</param>
         /// <param name="context">The node within which to sanitize.</param>
         /// <param name="baseUrl">The base URL relative URLs are resolved against. No resolution if empty.</param>
         /// <returns>The sanitized HTML Document.</returns>
         public IHtmlDocument SanitizeDom(IHtmlDocument document, IHtmlElement context = null, string baseUrl = "")
         {
-            if (context == null)
-            {
-                DoSanitize(document, document, baseUrl);
-            }
-            else
-            {
-                DoSanitize(document, context, baseUrl);
-            }
-
+            var styling = document.Context.GetCssStyling();
+            DoSanitize(document, context ?? (IParentNode) document, baseUrl);
             return document;
         }
 
@@ -873,7 +866,8 @@ namespace Ganss.XSS
         {
             // filter out invalid CSS declarations
             // see https://github.com/AngleSharp/AngleSharp/issues/101
-            if (element.GetAttribute("style") == null) return;
+            var attribute = element.GetAttribute("style");
+            if (attribute == null) return;
             if (element.GetStyle() == null)
             {
                 element.RemoveAttribute("style");

--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -589,7 +589,6 @@ namespace Ganss.XSS
         /// <returns>The sanitized HTML Document.</returns>
         public IHtmlDocument SanitizeDom(IHtmlDocument document, IHtmlElement context = null, string baseUrl = "")
         {
-            var styling = document.Context.GetCssStyling();
             DoSanitize(document, context ?? (IParentNode) document, baseUrl);
             return document;
         }

--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -580,8 +580,7 @@ namespace Ganss.XSS
 
         /// <summary>
         /// Sanitizes the specified parsed HTML body fragment.
-        /// The Document Must have been parsed with CSS support and the following options enabled
-        /// "IsIncludingUnknownDeclarations", "IsIncludingUnknownRules" and "IsToleratingInvalidSelectors"
+        /// The Document must have been parsed with CSS support.
         /// </summary>
         /// <param name="document">The parsed HTML Document.</param>
         /// <param name="context">The node within which to sanitize.</param>

--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -580,7 +580,7 @@ namespace Ganss.XSS
 
         /// <summary>
         /// Sanitizes the specified parsed HTML body fragment.
-        /// The Document must have been parsed with CSS support.
+        /// If the document has not been parsed with CSS support then all styles will be removed
         /// </summary>
         /// <param name="document">The parsed HTML Document.</param>
         /// <param name="context">The node within which to sanitize.</param>

--- a/src/HtmlSanitizer/IHtmlSanitizer.cs
+++ b/src/HtmlSanitizer/IHtmlSanitizer.cs
@@ -157,7 +157,7 @@ namespace Ganss.XSS
 
         /// <summary>
         /// Sanitizes the specified parsed HTML body fragment.
-        /// The Document must have been parsed with CSS support.
+        /// If the document has not been parsed with CSS support then all styles will be removed
         /// </summary>
         /// <param name="document">The parsed HTML Document.</param>
         /// <param name="context">The node within which to sanitize.</param>

--- a/src/HtmlSanitizer/IHtmlSanitizer.cs
+++ b/src/HtmlSanitizer/IHtmlSanitizer.cs
@@ -156,6 +156,16 @@ namespace Ganss.XSS
         IHtmlDocument SanitizeDom(string html, string baseUrl = "");
 
         /// <summary>
+        /// Sanitizes the specified parsed HTML body fragment.
+        /// The Document Must have been pared with CSS support and the following options enabled
+        /// "IsIncludingUnknownDeclarations", "IsIncludingUnknownRules" and "IsToleratingInvalidSelectors"
+        /// </summary>
+        /// <param name="document">The pared HTML Document.</param>
+        /// <param name="baseUrl">The base URL relative URLs are resolved against. No resolution if empty.</param>
+        /// <returns>The sanitized HTML Document.</returns>
+        IHtmlDocument SanitizeDom(IHtmlDocument document, string baseUrl = "");
+
+        /// <summary>
         /// Sanitizes the specified HTML document. Even if only a fragment is given, a whole document will be returned.
         /// </summary>
         /// <param name="html">The HTML document to sanitize.</param>

--- a/src/HtmlSanitizer/IHtmlSanitizer.cs
+++ b/src/HtmlSanitizer/IHtmlSanitizer.cs
@@ -157,8 +157,7 @@ namespace Ganss.XSS
 
         /// <summary>
         /// Sanitizes the specified parsed HTML body fragment.
-        /// The Document Must have been parsed with CSS support and the following options enabled
-        /// "IsIncludingUnknownDeclarations", "IsIncludingUnknownRules" and "IsToleratingInvalidSelectors"
+        /// The Document must have been parsed with CSS support.
         /// </summary>
         /// <param name="document">The parsed HTML Document.</param>
         /// <param name="context">The node within which to sanitize.</param>

--- a/src/HtmlSanitizer/IHtmlSanitizer.cs
+++ b/src/HtmlSanitizer/IHtmlSanitizer.cs
@@ -160,10 +160,11 @@ namespace Ganss.XSS
         /// The Document Must have been pared with CSS support and the following options enabled
         /// "IsIncludingUnknownDeclarations", "IsIncludingUnknownRules" and "IsToleratingInvalidSelectors"
         /// </summary>
-        /// <param name="document">The pared HTML Document.</param>
+        /// <param name="document">The parsed HTML Document.</param>
+        /// <param name="context">The node within which to sanitize.</param>
         /// <param name="baseUrl">The base URL relative URLs are resolved against. No resolution if empty.</param>
         /// <returns>The sanitized HTML Document.</returns>
-        IHtmlDocument SanitizeDom(IHtmlDocument document, string baseUrl = "");
+        IHtmlDocument SanitizeDom(IHtmlDocument document, IHtmlElement context = null, string baseUrl = "");
 
         /// <summary>
         /// Sanitizes the specified HTML document. Even if only a fragment is given, a whole document will be returned.

--- a/src/HtmlSanitizer/IHtmlSanitizer.cs
+++ b/src/HtmlSanitizer/IHtmlSanitizer.cs
@@ -157,7 +157,7 @@ namespace Ganss.XSS
 
         /// <summary>
         /// Sanitizes the specified parsed HTML body fragment.
-        /// The Document Must have been pared with CSS support and the following options enabled
+        /// The Document Must have been parsed with CSS support and the following options enabled
         /// "IsIncludingUnknownDeclarations", "IsIncludingUnknownRules" and "IsToleratingInvalidSelectors"
         /// </summary>
         /// <param name="document">The parsed HTML Document.</param>

--- a/test/HtmlSanitizer.Tests/Tests.cs
+++ b/test/HtmlSanitizer.Tests/Tests.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using AngleSharp.Css.Parser;
 using Xunit;
 
 // Tests based on tests from http://roadkill.codeplex.com/
@@ -3161,6 +3162,44 @@ zqy1QY1kkPOuMvKWvvmFIwClI2393jVVcp91eda4+J+fIYDbfJa7RY5YcNrZhTuV//9k="">
             var actual = sanitizer.SanitizeDocument(html);
 
             Assert.Equal("<html><head></head><body></body></html>", actual);
+        }
+        
+        [Fact]
+        public void PreParsedDocumentWithoutContextTest()
+        {
+            // parse a document before calling SantizeDom
+            var sanitizer = new HtmlSanitizer();
+            var parser = new HtmlParser(new HtmlParserOptions(), BrowsingContext.New(new Configuration().WithCss(new CssParserOptions
+            {
+                IsIncludingUnknownDeclarations = true,
+                IsIncludingUnknownRules = true,
+                IsToleratingInvalidSelectors = true,
+            })));
+            var html = @"<html><head></head><body><div>hi</div></body></html>";
+
+            var document = parser.ParseDocument(html);
+            var returnedDocument = sanitizer.SanitizeDom(document);
+
+            Assert.Equal("<html><head></head><body><div>hi</div></body></html>", returnedDocument.ToHtml());
+        }
+        
+        [Fact]
+        public void PreParsedDocumentWithContextTest()
+        {
+            // parse a document before calling SantizeDom
+            var sanitizer = new HtmlSanitizer();
+            var parser = new HtmlParser(new HtmlParserOptions(), BrowsingContext.New(new Configuration().WithCss(new CssParserOptions
+            {
+                IsIncludingUnknownDeclarations = true,
+                IsIncludingUnknownRules = true,
+                IsToleratingInvalidSelectors = true,
+            })));
+            var html = @"<html><head></head><body><div>hi</div></body></html>";
+
+            var document = parser.ParseDocument(html);
+            var returnedDocument = sanitizer.SanitizeDom(document, document.Body);
+
+            Assert.Equal("<html><head></head><body><div>hi</div></body></html>", returnedDocument.ToHtml());
         }
     }
 }

--- a/test/HtmlSanitizer.Tests/Tests.cs
+++ b/test/HtmlSanitizer.Tests/Tests.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using AngleSharp.Css.Parser;
 using Xunit;
 
 // Tests based on tests from http://roadkill.codeplex.com/
@@ -436,6 +437,27 @@ S
             // Assert
             string expected = "<img>";
             Assert.Equal(expected, actual, ignoreCase: true);
+        }
+        
+        
+        [Fact]
+        public void TomTest()
+        {
+            // Arrange
+            var sanitizer = Sanitizer;
+            sanitizer.AllowedTags.Add("style");
+            var parser = new HtmlParser(new HtmlParserOptions(), BrowsingContext.New(new Configuration().WithCss()));
+
+
+            // Act
+            string htmlFragment = "<div style=\"notarealthing: red;\">test test </div>";
+            var doc = parser.ParseDocument(htmlFragment);
+            
+            var newDom = sanitizer.SanitizeDom(doc);
+
+            // Assert
+            string expected = "<img>";
+            // Assert.Equal(expected, actual, ignoreCase: true)
         }
 
         /// <summary>

--- a/test/HtmlSanitizer.Tests/Tests.cs
+++ b/test/HtmlSanitizer.Tests/Tests.cs
@@ -11,7 +11,6 @@ using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
-using AngleSharp.Css.Parser;
 using Xunit;
 
 // Tests based on tests from http://roadkill.codeplex.com/
@@ -439,27 +438,6 @@ S
             Assert.Equal(expected, actual, ignoreCase: true);
         }
         
-        
-        [Fact]
-        public void TomTest()
-        {
-            // Arrange
-            var sanitizer = Sanitizer;
-            sanitizer.AllowedTags.Add("style");
-            var parser = new HtmlParser(new HtmlParserOptions(), BrowsingContext.New(new Configuration().WithCss()));
-
-
-            // Act
-            string htmlFragment = "<div style=\"notarealthing: red;\">test test </div>";
-            var doc = parser.ParseDocument(htmlFragment);
-            
-            var newDom = sanitizer.SanitizeDom(doc);
-
-            // Assert
-            string expected = "<img>";
-            // Assert.Equal(expected, actual, ignoreCase: true)
-        }
-
         /// <summary>
         /// A test for Image Xss vector with Null breaks up cross site scripting vector
         /// Example <!-- <image src=" perl -e 'print "<SCR\0IPT>alert(\"XSS\")</SCR\0IPT>";' > out "> -->


### PR DESCRIPTION
### Why
In my use case I have already used anglesharp to parse the document before calling `.SanitizeDocument` and i need to do more work after calling `.SanitizeDocument`. This means that in this section anglesharp is parsing the document 3 times, on a large document with CSS support that can be quite slow. 

### What
I have added an extra external API with the same `SanitizeDom` name as it seemed to fit (not sure ifs its technically the correct place however).

### Potential issues
- If the document is parsed without css support that will cause issues, i have added this in the summary method docs, but im not sure if its possible to tell at runtime if it has been pared with css support and throw a reasonable exception.