### PR TITLE
Reuse configuration

### DIFF
--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -50,6 +50,13 @@ namespace Ganss.XSS
     /// </example>
     public class HtmlSanitizer : IHtmlSanitizer
     {
+        private static readonly IConfiguration defaultConfiguration = Configuration.Default.WithCss(new CssParserOptions
+        {
+            IsIncludingUnknownDeclarations = true,
+            IsIncludingUnknownRules = true,
+            IsToleratingInvalidSelectors = true,
+        });
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="HtmlSanitizer"/> class.
         /// </summary>
@@ -638,12 +645,7 @@ namespace Ganss.XSS
         /// <returns>An instance of <see cref="HtmlParser"/>.</returns>
         private static HtmlParser CreateParser()
         {
-            return new HtmlParser(new HtmlParserOptions(), BrowsingContext.New(new Configuration().WithCss(new CssParserOptions
-            {
-                IsIncludingUnknownDeclarations = true,
-                IsIncludingUnknownRules = true,
-                IsToleratingInvalidSelectors = true,
-            })));
+            return new HtmlParser(new HtmlParserOptions(), BrowsingContext.New(defaultConfiguration));
         }
 
         /// <summary>


### PR DESCRIPTION
While profiling Orchard Core CMS I noticed that a lot of allocating (and costly) calls were made to `new Configuration()` and `WithCss`. I believe these are constructs that generate immutable data structures so this configuration can be reused between calls.

~~I also removed some unnecessary `ToList` calls which materialize collections that are traversed by `foreach` loops, the original enumerator is enough to loop them without actually creating intermediate materialized collection.~~

EDIT: reverted the `ToList` removal, current logic seems to require materialization

/cc @sebastienros