### PR TITLE
Include html Tag in FilterUrlEventArgs

### DIFF
--- a/src/HtmlSanitizer/EventArgs.cs
+++ b/src/HtmlSanitizer/EventArgs.cs
@@ -309,14 +309,24 @@ namespace Ganss.XSS
         public string? SanitizedUrl { get; set; }
 
         /// <summary>
+        /// Gets or sets the tag containing the URI being sanitized.
+        /// </summary>
+        /// <value>
+        /// The tag.
+        /// </value>
+        public IElement Tag { get; private set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="FilterUrlEventArgs"/> class.
         /// </summary>
+        /// <param name="tag">The tag containing the URI being sanitized.</param>
         /// <param name="originalUrl">The original URL.</param>
         /// <param name="sanitizedUrl">The sanitized URL.</param>
-        public FilterUrlEventArgs(string originalUrl, string? sanitizedUrl = null)
+        public FilterUrlEventArgs(IElement tag, string originalUrl, string? sanitizedUrl = null)
         {
             OriginalUrl = originalUrl;
             SanitizedUrl = sanitizedUrl;
+            Tag = tag;
         }
     }
 }

--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -679,7 +679,7 @@ namespace Ganss.XSS
                 // sanitize URLs in URL-marked attributes
                 foreach (var attribute in tag.Attributes.Where(IsUriAttribute).ToList())
                 {
-                    var url = SanitizeUrl(attribute.Value, baseUrl);
+                    var url = SanitizeUrl(tag, attribute.Value, baseUrl);
                     if (url == null)
                         RemoveAttribute(tag, attribute, RemoveReason.NotAllowedUrlValue);
                     else
@@ -895,11 +895,11 @@ namespace Ganss.XSS
 
                 if (urls.Count > 0)
                 {
-                    if (urls.Cast<Match>().Any(m => SanitizeUrl(m.Groups[2].Value, baseUrl) == null))
+                    if (urls.Cast<Match>().Any(m => SanitizeUrl(element, m.Groups[2].Value, baseUrl) == null))
                         removeStyles.Add(new Tuple<ICssProperty, RemoveReason>(style, RemoveReason.NotAllowedUrlValue));
                     else
                     {
-                        var s = CssUrl.Replace(val, m => "url(" + m.Groups[1].Value + SanitizeUrl(m.Groups[2].Value, baseUrl) + m.Groups[3].Value);
+                        var s = CssUrl.Replace(val, m => "url(" + m.Groups[1].Value + SanitizeUrl(element, m.Groups[2].Value, baseUrl) + m.Groups[3].Value);
                         if (s != val)
                         {
                             if (key != style.Name)
@@ -966,10 +966,11 @@ namespace Ganss.XSS
         /// <summary>
         /// Sanitizes a URL.
         /// </summary>
+        /// <param name="element">The tag containing the URL being sanitized</param>
         /// <param name="url">The URL.</param>
         /// <param name="baseUrl">The base URL relative URLs are resolved against (empty or null for no resolution).</param>
         /// <returns>The sanitized URL or null if no safe URL can be created.</returns>
-        protected virtual string? SanitizeUrl(string url, string baseUrl)
+        protected virtual string? SanitizeUrl(IElement element, string url, string baseUrl)
         {
             var iri = GetSafeIri(url);
 
@@ -992,7 +993,7 @@ namespace Ganss.XSS
                 else iri = null;
             }
 
-            var e = new FilterUrlEventArgs(url, iri?.Value);
+            var e = new FilterUrlEventArgs(element, url, iri?.Value);
             OnFilteringUrl(e);
 
             return e.SanitizedUrl;


### PR DESCRIPTION
For our use case we would like to be able to selectively sanitize data URI's based on the tag they are in (allow in an img tag, disallow any where else).

So to enable this I have modified the FilterUrlEventArgs to include the html tag that the URL is being sanitized from allowing us to include this logic in the FilterUrl call back.

Any comments or other way of achieving our goal appreciated.