### PR TITLE
Fix issue with exception when strictmode is enabled

### DIFF
--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -194,7 +194,7 @@ namespace Ganss.XSS
         /// <summary>
         /// The default allowed HTML attributes.
         /// </summary>
-        public static ISet<string> DefaultAllowedAttributes { get; }  = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+        public static ISet<string> DefaultAllowedAttributes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
             // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
             "abbr", "accept", "accept-charset", "accesskey",
             "action", "align", "alt", "axis", "bgcolor", "border", "cellpadding",
@@ -583,7 +583,7 @@ namespace Ganss.XSS
         public IHtmlDocument SanitizeDom(string html, string baseUrl = "")
         {
             var parser = HtmlParserFactory();
-            var dom = parser.ParseDocument("<html><body>" + html);
+            var dom = parser.ParseDocument("<!doctype html><html><body>" + html);
 
             if (dom.Body != null)
                 DoSanitize(dom, dom.Body, baseUrl);
@@ -601,7 +601,7 @@ namespace Ganss.XSS
         /// <returns>The sanitized HTML document.</returns>
         public IHtmlDocument SanitizeDom(IHtmlDocument document, IHtmlElement? context = null, string baseUrl = "")
         {
-            DoSanitize(document, context ?? (IParentNode) document, baseUrl);
+            DoSanitize(document, context ?? (IParentNode)document, baseUrl);
             return document;
         }
 

--- a/test/HtmlSanitizer.Tests/Tests.cs
+++ b/test/HtmlSanitizer.Tests/Tests.cs
@@ -30,7 +30,7 @@ namespace Ganss.XSS.Tests
     /// <summary>
     /// Tests for <see cref="HtmlSanitizer"/>.
     /// </summary>
-    public class HtmlSanitizerTests: IClassFixture<HtmlSanitizerFixture>
+    public class HtmlSanitizerTests : IClassFixture<HtmlSanitizerFixture>
     {
         public HtmlSanitizer Sanitizer { get; set; }
 
@@ -2370,7 +2370,7 @@ rl(javascript:alert(""foo""))'>";
         [Fact]
         public void RemoveEventForNotAllowedTag()
         {
-            var allowedTags = new[] {"a"};
+            var allowedTags = new[] { "a" };
             RemoveReason? actual = null;
 
             var s = new HtmlSanitizer(allowedTags);
@@ -2388,7 +2388,7 @@ rl(javascript:alert(""foo""))'>";
         public void RemoveEventForNotAllowedAttribute()
         {
             var allowedTags = new[] { "a" };
-            var allowedAttributes = new[] {"id"};
+            var allowedAttributes = new[] { "id" };
             RemoveReason? actual = null;
 
             var s = new HtmlSanitizer(allowedTags: allowedTags, allowedAttributes: allowedAttributes);
@@ -3236,6 +3236,25 @@ zqy1QY1kkPOuMvKWvvmFIwClI2393jVVcp91eda4+J+fIYDbfJa7RY5YcNrZhTuV//9k="">
             var html = @"<span style='grid-template-areas: none; grid-template-columns: none; grid-template-rows: none'>";
             var sanitized = Sanitizer.Sanitize(html);
             Assert.Equal("<span></span>", sanitized);
+        }
+
+        [Fact]
+        public void Number307StrictModeValidHtmlTest()
+        {
+            // see https://github.com/mganss/HtmlSanitizer/issues/307
+            var html = @"<div>This is <p>Paragraph</p></div>";
+            var s = new HtmlSanitizer { HtmlParserFactory = () => new HtmlParser(new HtmlParserOptions { IsStrictMode = true }) };
+            var sanitized = s.Sanitize(html);
+            Assert.Equal("<div>This is <p>Paragraph</p></div>", sanitized);
+        }
+
+        [Fact]
+        public void Number307StrictModeIllHtmlTest()
+        {
+            // see https://github.com/mganss/HtmlSanitizer/issues/307
+            var html = @"<div>This is <p>Paragraph/div>";
+            var s = new HtmlSanitizer { HtmlParserFactory = () => new HtmlParser(new HtmlParserOptions { IsStrictMode = true }) };
+            Assert.Throws<HtmlParseException>(() => s.Sanitize(html));
         }
     }
 }


### PR DESCRIPTION
Pull request will address issue with IsStrictMode enabled. Before this change HtmlSanitizer.Sanitize() would throw error for valid html, with this change <!doctype html> is added before parsing html allowing strict mode to work as intended. This should not introduce breaking changes. Added two tests to confirm that this pull request address this issue and not breaking existing functionalities.

Other changes are formats.

Fixes #307 