### PR TITLE
Return ICollection instead of IList

### DIFF
--- a/src/HtmlSanitizer/EventArgs.cs
+++ b/src/HtmlSanitizer/EventArgs.cs
@@ -56,7 +56,7 @@ namespace Ganss.XSS
         /// <value>
         /// The replacement nodes.
         /// </value>
-        public IList<INode> ReplacementNodes { get; private set; }
+        public ICollection<INode> ReplacementNodes { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PostProcessNodeEventArgs"/> class.


### PR DESCRIPTION
Follow Microsoft's Framework Design Guidelines.

> ✔️ DO use `Collection<T>` or a subclass of `Collection<T>` for properties or return values representing read/write collections.

https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/guidelines-for-collections