### PR TITLE
Refactor out defaults to separate file

### DIFF
--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -84,11 +84,11 @@ namespace Ganss.XSS
         /// <summary>
         /// Initializes a new instance of the <see cref="HtmlSanitizer"/> class.
         /// </summary>
-        /// <param name="allowedTags">The allowed tag names such as "a" and "div". When <c>null</c>, uses <see cref="DefaultAllowedTags"/></param>
-        /// <param name="allowedSchemes">The allowed URI schemes such as "http" and "https". When <c>null</c>, uses <see cref="DefaultAllowedSchemes"/></param>
-        /// <param name="allowedAttributes">The allowed HTML attributes such as "href" and "alt". When <c>null</c>, uses <see cref="DefaultAllowedAttributes"/></param>
-        /// <param name="uriAttributes">The HTML attributes that can contain a URI such as "href". When <c>null</c>, uses <see cref="DefaultUriAttributes"/></param>
-        /// <param name="allowedCssProperties">The allowed CSS properties such as "font" and "margin". When <c>null</c>, uses <see cref="DefaultAllowedCssProperties"/></param>
+        /// <param name="allowedTags">The allowed tag names such as "a" and "div". When <c>null</c>, uses <see cref="HtmlSanitizerDefaults.DefaultAllowedTags"/></param>
+        /// <param name="allowedSchemes">The allowed URI schemes such as "http" and "https". When <c>null</c>, uses <see cref="HtmlSanitizerDefaults.DefaultAllowedSchemes"/></param>
+        /// <param name="allowedAttributes">The allowed HTML attributes such as "href" and "alt". When <c>null</c>, uses <see cref="HtmlSanitizerDefaults.DefaultAllowedAttributes"/></param>
+        /// <param name="uriAttributes">The HTML attributes that can contain a URI such as "href". When <c>null</c>, uses <see cref="HtmlSanitizerDefaults.DefaultUriAttributes"/></param>
+        /// <param name="allowedCssProperties">The allowed CSS properties such as "font" and "margin". When <c>null</c>, uses <see cref="HtmlSanitizerDefaults.DefaultAllowedCssProperties"/></param>
         public HtmlSanitizer(IEnumerable<string>? allowedTags = null, IEnumerable<string>? allowedSchemes = null,
             IEnumerable<string>? allowedAttributes = null, IEnumerable<string>? uriAttributes = null, IEnumerable<string>? allowedCssProperties = null)
         {
@@ -106,13 +106,13 @@ namespace Ganss.XSS
                 allowedCssProperties = null;
             }
 
-            AllowedTags = new HashSet<string>(allowedTags ?? DefaultAllowedTags, StringComparer.OrdinalIgnoreCase);
-            AllowedSchemes = new HashSet<string>(allowedSchemes ?? DefaultAllowedSchemes, StringComparer.OrdinalIgnoreCase);
-            AllowedAttributes = new HashSet<string>(allowedAttributes ?? DefaultAllowedAttributes, StringComparer.OrdinalIgnoreCase);
-            UriAttributes = new HashSet<string>(uriAttributes ?? DefaultUriAttributes, StringComparer.OrdinalIgnoreCase);
-            AllowedCssProperties = new HashSet<string>(allowedCssProperties ?? DefaultAllowedCssProperties, StringComparer.OrdinalIgnoreCase);
-            AllowedAtRules = new HashSet<CssRuleType>(DefaultAllowedAtRules);
-            AllowedClasses = new HashSet<string>(DefaultAllowedClasses, StringComparer.OrdinalIgnoreCase);
+            AllowedTags = new HashSet<string>(allowedTags ?? HtmlSanitizerDefaults.DefaultAllowedTags, StringComparer.OrdinalIgnoreCase);
+            AllowedSchemes = new HashSet<string>(allowedSchemes ?? HtmlSanitizerDefaults.DefaultAllowedSchemes, StringComparer.OrdinalIgnoreCase);
+            AllowedAttributes = new HashSet<string>(allowedAttributes ?? HtmlSanitizerDefaults.DefaultAllowedAttributes, StringComparer.OrdinalIgnoreCase);
+            UriAttributes = new HashSet<string>(uriAttributes ?? HtmlSanitizerDefaults.DefaultUriAttributes, StringComparer.OrdinalIgnoreCase);
+            AllowedCssProperties = new HashSet<string>(allowedCssProperties ?? HtmlSanitizerDefaults.DefaultAllowedCssProperties, StringComparer.OrdinalIgnoreCase);
+            AllowedAtRules = new HashSet<CssRuleType>(HtmlSanitizerDefaults.DefaultAllowedAtRules);
+            AllowedClasses = new HashSet<string>(HtmlSanitizerDefaults.DefaultAllowedClasses, StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -164,11 +164,6 @@ namespace Ganss.XSS
         public ISet<CssRuleType> AllowedAtRules { get; private set; }
 
         /// <summary>
-        /// The default allowed CSS at-rules.
-        /// </summary>
-        public static ISet<CssRuleType> DefaultAllowedAtRules { get; } = new HashSet<CssRuleType>() { CssRuleType.Style, CssRuleType.Namespace };
-
-        /// <summary>
         /// Gets or sets the allowed URI schemes such as "http" and "https".
         /// </summary>
         /// <value>
@@ -177,46 +172,12 @@ namespace Ganss.XSS
         public ISet<string> AllowedSchemes { get; private set; }
 
         /// <summary>
-        /// The default allowed URI schemes.
-        /// </summary>
-        public static ISet<string> DefaultAllowedSchemes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "http", "https" };
-
-        /// <summary>
         /// Gets or sets the allowed HTML tag names such as "a" and "div".
         /// </summary>
         /// <value>
         /// The allowed tag names.
         /// </value>
         public ISet<string> AllowedTags { get; private set; }
-
-        /// <summary>
-        /// The default allowed HTML tag names.
-        /// </summary>
-        public static ISet<string> DefaultAllowedTags { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
-            // https://developer.mozilla.org/en/docs/Web/Guide/HTML/HTML5/HTML5_element_list
-            "a", "abbr", "acronym", "address", "area", "b",
-            "big", "blockquote", "br", "button", "caption", "center", "cite",
-            "code", "col", "colgroup", "dd", "del", "dfn", "dir", "div", "dl", "dt",
-            "em", "fieldset", "font", "form", "h1", "h2", "h3", "h4", "h5", "h6",
-            "hr", "i", "img", "input", "ins", "kbd", "label", "legend", "li", "map",
-            "menu", "ol", "optgroup", "option", "p", "pre", "q", "s", "samp",
-            "select", "small", "span", "strike", "strong", "sub", "sup", "table",
-            "tbody", "td", "textarea", "tfoot", "th", "thead", "tr", "tt", "u",
-            "ul", "var",
-            // HTML5
-            // Sections
-            "section", "nav", "article", "aside", "header", "footer", "main",
-            // Grouping content
-            "figure", "figcaption",
-            // Text-level semantics
-            "data", "time", "mark", "ruby", "rt", "rp", "bdi", "wbr",
-            // Forms
-            "datalist", "keygen", "output", "progress", "meter",
-            // Interactive elements
-            "details", "summary", "menuitem",
-            // document elements
-            "html", "head", "body"
-        };
 
         /// <summary>
         /// Gets or sets the allowed HTML attributes such as "href" and "alt".
@@ -232,60 +193,12 @@ namespace Ganss.XSS
         public bool AllowDataAttributes { get; set; }
 
         /// <summary>
-        /// The default allowed HTML attributes.
-        /// </summary>
-        public static ISet<string> DefaultAllowedAttributes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
-            // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
-            "abbr", "accept", "accept-charset", "accesskey",
-            "action", "align", "alt", "axis", "bgcolor", "border", "cellpadding",
-            "cellspacing", "char", "charoff", "charset", "checked", "cite", /* "class", */
-            "clear", "cols", "colspan", "color", "compact", "coords", "datetime",
-            "dir", "disabled", "enctype", "for", "frame", "headers", "height",
-            "href", "hreflang", "hspace", /* "id", */ "ismap", "label", "lang",
-            "longdesc", "maxlength", "media", "method", "multiple", "name",
-            "nohref", "noshade", "nowrap", "prompt", "readonly", "rel", "rev",
-            "rows", "rowspan", "rules", "scope", "selected", "shape", "size",
-            "span", "src", "start", "style", "summary", "tabindex", "target", "title",
-            "type", "usemap", "valign", "value", "vspace", "width",
-            // HTML5
-            "high", // <meter>
-            "keytype", // <keygen>
-            "list", // <input>
-            "low", // <meter>
-            "max", // <input>, <meter>, <progress>
-            "min", // <input>, <meter>
-            "novalidate", // <form>
-            "open", // <details>
-            "optimum", // <meter>
-            "pattern", // <input>
-            "placeholder", // <input>, <textarea>
-            "pubdate", // <time>
-            "radiogroup", // <menuitem>
-            "required", // <input>, <select>, <textarea>
-            "reversed", // <ol>
-            "spellcheck", // Global attribute
-            "step", // <input>
-            "wrap", // <textarea>
-            "challenge", // <keygen>
-            "contenteditable", // Global attribute
-            "draggable", // Global attribute
-            "dropzone", // Global attribute
-            "autocomplete", // <form>, <input>
-            "autosave", // <input>
-        };
-
-        /// <summary>
         /// Gets or sets the HTML attributes that can contain a URI such as "href".
         /// </summary>
         /// <value>
         /// The URI attributes.
         /// </value>
         public ISet<string> UriAttributes { get; private set; }
-
-        /// <summary>
-        /// The default URI attributes.
-        /// </summary>
-        public static ISet<string> DefaultUriAttributes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "action", "background", "dynsrc", "href", "lowsrc", "src" };
 
         /// <summary>
         /// Gets or sets the allowed CSS properties such as "font" and "margin".
@@ -296,264 +209,12 @@ namespace Ganss.XSS
         public ISet<string> AllowedCssProperties { get; private set; }
 
         /// <summary>
-        /// The default allowed CSS properties.
-        /// </summary>
-        public static ISet<string> DefaultAllowedCssProperties { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            // CSS 3 properties <http://www.w3.org/TR/CSS/#properties>
-            "align-content",
-            "align-items",
-            "align-self",
-            "all",
-            "animation",
-            "animation-delay",
-            "animation-direction",
-            "animation-duration",
-            "animation-fill-mode",
-            "animation-iteration-count",
-            "animation-name",
-            "animation-play-state",
-            "animation-timing-function",
-            "backface-visibility",
-            "background",
-            "background-attachment",
-            "background-blend-mode",
-            "background-clip",
-            "background-color",
-            "background-image",
-            "background-origin",
-            "background-position",
-            "background-position-x",
-            "background-position-y",
-            "background-repeat",
-            "background-repeat-x", // see https://github.com/mganss/HtmlSanitizer/issues/243
-            "background-repeat-y",
-            "background-size",
-            "border",
-            "border-bottom",
-            "border-bottom-color",
-            "border-bottom-left-radius",
-            "border-bottom-right-radius",
-            "border-bottom-style",
-            "border-bottom-width",
-            "border-collapse",
-            "border-color",
-            "border-image",
-            "border-image-outset",
-            "border-image-repeat",
-            "border-image-slice",
-            "border-image-source",
-            "border-image-width",
-            "border-left",
-            "border-left-color",
-            "border-left-style",
-            "border-left-width",
-            "border-radius",
-            "border-right",
-            "border-right-color",
-            "border-right-style",
-            "border-right-width",
-            "border-spacing",
-            "border-style",
-            "border-top",
-            "border-top-color",
-            "border-top-left-radius",
-            "border-top-right-radius",
-            "border-top-style",
-            "border-top-width",
-            "border-width",
-            "bottom",
-            "box-decoration-break",
-            "box-shadow",
-            "box-sizing",
-            "break-after",
-            "break-before",
-            "break-inside",
-            "caption-side",
-            "caret-color",
-            "clear",
-            "clip",
-            "color",
-            "column-count",
-            "column-fill",
-            "column-gap",
-            "column-rule",
-            "column-rule-color",
-            "column-rule-style",
-            "column-rule-width",
-            "column-span",
-            "column-width",
-            "columns",
-            "content",
-            "counter-increment",
-            "counter-reset",
-            "cursor",
-            "direction",
-            "display",
-            "empty-cells",
-            "filter",
-            "flex",
-            "flex-basis",
-            "flex-direction",
-            "flex-flow",
-            "flex-grow",
-            "flex-shrink",
-            "flex-wrap",
-            "float",
-            "font",
-            "font-family",
-            "font-feature-settings",
-            "font-kerning",
-            "font-language-override",
-            "font-size",
-            "font-size-adjust",
-            "font-stretch",
-            "font-style",
-            "font-synthesis",
-            "font-variant",
-            "font-variant-alternates",
-            "font-variant-caps",
-            "font-variant-east-asian",
-            "font-variant-ligatures",
-            "font-variant-numeric",
-            "font-variant-position",
-            "font-weight",
-            "gap",
-            "grid",
-            "grid-area",
-            "grid-auto-columns",
-            "grid-auto-flow",
-            "grid-auto-rows",
-            "grid-column",
-            "grid-column-end",
-            "grid-column-gap",
-            "grid-column-start",
-            "grid-gap",
-            "grid-row",
-            "grid-row-end",
-            "grid-row-gap",
-            "grid-row-start",
-            "grid-template",
-            "grid-template-areas",
-            "grid-template-columns",
-            "grid-template-rows",
-            "hanging-punctuation",
-            "height",
-            "hyphens",
-            "image-rendering",
-            "isolation",
-            "justify-content",
-            "left",
-            "letter-spacing",
-            "line-break",
-            "line-height",
-            "list-style",
-            "list-style-image",
-            "list-style-position",
-            "list-style-type",
-            "margin",
-            "margin-bottom",
-            "margin-left",
-            "margin-right",
-            "margin-top",
-            "mask",
-            "mask-clip",
-            "mask-composite",
-            "mask-image",
-            "mask-mode",
-            "mask-origin",
-            "mask-position",
-            "mask-repeat",
-            "mask-size",
-            "mask-type",
-            "max-height",
-            "max-width",
-            "min-height",
-            "min-width",
-            "mix-blend-mode",
-            "object-fit",
-            "object-position",
-            "opacity",
-            "order",
-            "orphans",
-            "outline",
-            "outline-color",
-            "outline-offset",
-            "outline-style",
-            "outline-width",
-            "overflow",
-            "overflow-wrap",
-            "overflow-x",
-            "overflow-y",
-            "padding",
-            "padding-bottom",
-            "padding-left",
-            "padding-right",
-            "padding-top",
-            "page-break-after",
-            "page-break-before",
-            "page-break-inside",
-            "perspective",
-            "perspective-origin",
-            "pointer-events",
-            "position",
-            "quotes",
-            "resize",
-            "right",
-            "row-gap",
-            "scroll-behavior",
-            "tab-size",
-            "table-layout",
-            "text-align",
-            "text-align-last",
-            "text-combine-upright",
-            "text-decoration",
-            "text-decoration-color",
-            "text-decoration-line",
-            "text-decoration-skip",
-            "text-decoration-style",
-            "text-indent",
-            "text-justify",
-            "text-orientation",
-            "text-overflow",
-            "text-shadow",
-            "text-transform",
-            "text-underline-position",
-            "top",
-            "transform",
-            "transform-origin",
-            "transform-style",
-            "transition",
-            "transition-delay",
-            "transition-duration",
-            "transition-property",
-            "transition-timing-function",
-            "unicode-bidi",
-            "user-select",
-            "vertical-align",
-            "visibility",
-            "white-space",
-            "widows",
-            "width",
-            "word-break",
-            "word-spacing",
-            "word-wrap",
-            "writing-mode",
-            "z-index"
-        };
-
-        /// <summary>
         /// Gets or sets a regex that must not match for legal CSS property values.
         /// </summary>
         /// <value>
         /// The regex.
         /// </value>
         public Regex DisallowCssPropertyValue { get; set; } = DefaultDisallowedCssPropertyValue;
-
-        /// <summary>
-        /// The default allowed CSS classes.
-        /// </summary>
-        public static ISet<string> DefaultAllowedClasses { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Gets or sets the allowed CSS classes. If the set is empty, all classes will be allowed.

--- a/src/HtmlSanitizer/HtmlSanitizerDefaults.cs
+++ b/src/HtmlSanitizer/HtmlSanitizerDefaults.cs
@@ -1,0 +1,362 @@
+using AngleSharp.Css.Dom;
+using System;
+using System.Collections.Generic;
+
+namespace Ganss.XSS
+{
+    /// <summary>
+    /// Default options.
+    /// </summary>
+    public static class HtmlSanitizerDefaults
+    {
+        /// <summary>
+        /// The default allowed CSS at-rules.
+        /// </summary>
+        public static ISet<CssRuleType> DefaultAllowedAtRules { get; } = new HashSet<CssRuleType>()
+        {
+            CssRuleType.Style, CssRuleType.Namespace
+        };
+
+        /// <summary>
+        /// The default allowed URI schemes.
+        /// </summary>
+        public static ISet<string> DefaultAllowedSchemes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "http", "https"
+        };
+
+        /// <summary>
+        /// The default allowed HTML tag names.
+        /// </summary>
+        public static ISet<string> DefaultAllowedTags { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // https://developer.mozilla.org/en/docs/Web/Guide/HTML/HTML5/HTML5_element_list
+            "a", "abbr", "acronym", "address", "area", "b",
+            "big", "blockquote", "br", "button", "caption", "center", "cite",
+            "code", "col", "colgroup", "dd", "del", "dfn", "dir", "div", "dl", "dt",
+            "em", "fieldset", "font", "form", "h1", "h2", "h3", "h4", "h5", "h6",
+            "hr", "i", "img", "input", "ins", "kbd", "label", "legend", "li", "map",
+            "menu", "ol", "optgroup", "option", "p", "pre", "q", "s", "samp",
+            "select", "small", "span", "strike", "strong", "sub", "sup", "table",
+            "tbody", "td", "textarea", "tfoot", "th", "thead", "tr", "tt", "u",
+            "ul", "var",
+            // HTML5
+            // Sections
+            "section", "nav", "article", "aside", "header", "footer", "main",
+            // Grouping content
+            "figure", "figcaption",
+            // Text-level semantics
+            "data", "time", "mark", "ruby", "rt", "rp", "bdi", "wbr",
+            // Forms
+            "datalist", "keygen", "output", "progress", "meter",
+            // Interactive elements
+            "details", "summary", "menuitem",
+            // document elements
+            "html", "head", "body"
+        };
+
+        /// <summary>
+        /// The default allowed HTML attributes.
+        /// </summary>
+        public static ISet<string> DefaultAllowedAttributes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
+            "abbr", "accept", "accept-charset", "accesskey",
+            "action", "align", "alt", "axis", "bgcolor", "border", "cellpadding",
+            "cellspacing", "char", "charoff", "charset", "checked", "cite", /* "class", */
+            "clear", "cols", "colspan", "color", "compact", "coords", "datetime",
+            "dir", "disabled", "enctype", "for", "frame", "headers", "height",
+            "href", "hreflang", "hspace", /* "id", */ "ismap", "label", "lang",
+            "longdesc", "maxlength", "media", "method", "multiple", "name",
+            "nohref", "noshade", "nowrap", "prompt", "readonly", "rel", "rev",
+            "rows", "rowspan", "rules", "scope", "selected", "shape", "size",
+            "span", "src", "start", "style", "summary", "tabindex", "target", "title",
+            "type", "usemap", "valign", "value", "vspace", "width",
+            // HTML5
+            "high", // <meter>
+            "keytype", // <keygen>
+            "list", // <input>
+            "low", // <meter>
+            "max", // <input>, <meter>, <progress>
+            "min", // <input>, <meter>
+            "novalidate", // <form>
+            "open", // <details>
+            "optimum", // <meter>
+            "pattern", // <input>
+            "placeholder", // <input>, <textarea>
+            "pubdate", // <time>
+            "radiogroup", // <menuitem>
+            "required", // <input>, <select>, <textarea>
+            "reversed", // <ol>
+            "spellcheck", // Global attribute
+            "step", // <input>
+            "wrap", // <textarea>
+            "challenge", // <keygen>
+            "contenteditable", // Global attribute
+            "draggable", // Global attribute
+            "dropzone", // Global attribute
+            "autocomplete", // <form>, <input>
+            "autosave", // <input>
+        };
+
+        /// <summary>
+        /// The default URI attributes.
+        /// </summary>
+        public static ISet<string> DefaultUriAttributes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "action", "background", "dynsrc", "href", "lowsrc", "src"
+        };
+
+        /// <summary>
+        /// The default allowed CSS properties.
+        /// </summary>
+        public static ISet<string> DefaultAllowedCssProperties { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // CSS 3 properties <http://www.w3.org/TR/CSS/#properties>
+            "align-content",
+            "align-items",
+            "align-self",
+            "all",
+            "animation",
+            "animation-delay",
+            "animation-direction",
+            "animation-duration",
+            "animation-fill-mode",
+            "animation-iteration-count",
+            "animation-name",
+            "animation-play-state",
+            "animation-timing-function",
+            "backface-visibility",
+            "background",
+            "background-attachment",
+            "background-blend-mode",
+            "background-clip",
+            "background-color",
+            "background-image",
+            "background-origin",
+            "background-position",
+            "background-position-x",
+            "background-position-y",
+            "background-repeat",
+            "background-repeat-x", // see https://github.com/mganss/HtmlSanitizer/issues/243
+            "background-repeat-y",
+            "background-size",
+            "border",
+            "border-bottom",
+            "border-bottom-color",
+            "border-bottom-left-radius",
+            "border-bottom-right-radius",
+            "border-bottom-style",
+            "border-bottom-width",
+            "border-collapse",
+            "border-color",
+            "border-image",
+            "border-image-outset",
+            "border-image-repeat",
+            "border-image-slice",
+            "border-image-source",
+            "border-image-width",
+            "border-left",
+            "border-left-color",
+            "border-left-style",
+            "border-left-width",
+            "border-radius",
+            "border-right",
+            "border-right-color",
+            "border-right-style",
+            "border-right-width",
+            "border-spacing",
+            "border-style",
+            "border-top",
+            "border-top-color",
+            "border-top-left-radius",
+            "border-top-right-radius",
+            "border-top-style",
+            "border-top-width",
+            "border-width",
+            "bottom",
+            "box-decoration-break",
+            "box-shadow",
+            "box-sizing",
+            "break-after",
+            "break-before",
+            "break-inside",
+            "caption-side",
+            "caret-color",
+            "clear",
+            "clip",
+            "color",
+            "column-count",
+            "column-fill",
+            "column-gap",
+            "column-rule",
+            "column-rule-color",
+            "column-rule-style",
+            "column-rule-width",
+            "column-span",
+            "column-width",
+            "columns",
+            "content",
+            "counter-increment",
+            "counter-reset",
+            "cursor",
+            "direction",
+            "display",
+            "empty-cells",
+            "filter",
+            "flex",
+            "flex-basis",
+            "flex-direction",
+            "flex-flow",
+            "flex-grow",
+            "flex-shrink",
+            "flex-wrap",
+            "float",
+            "font",
+            "font-family",
+            "font-feature-settings",
+            "font-kerning",
+            "font-language-override",
+            "font-size",
+            "font-size-adjust",
+            "font-stretch",
+            "font-style",
+            "font-synthesis",
+            "font-variant",
+            "font-variant-alternates",
+            "font-variant-caps",
+            "font-variant-east-asian",
+            "font-variant-ligatures",
+            "font-variant-numeric",
+            "font-variant-position",
+            "font-weight",
+            "gap",
+            "grid",
+            "grid-area",
+            "grid-auto-columns",
+            "grid-auto-flow",
+            "grid-auto-rows",
+            "grid-column",
+            "grid-column-end",
+            "grid-column-gap",
+            "grid-column-start",
+            "grid-gap",
+            "grid-row",
+            "grid-row-end",
+            "grid-row-gap",
+            "grid-row-start",
+            "grid-template",
+            "grid-template-areas",
+            "grid-template-columns",
+            "grid-template-rows",
+            "hanging-punctuation",
+            "height",
+            "hyphens",
+            "image-rendering",
+            "isolation",
+            "justify-content",
+            "left",
+            "letter-spacing",
+            "line-break",
+            "line-height",
+            "list-style",
+            "list-style-image",
+            "list-style-position",
+            "list-style-type",
+            "margin",
+            "margin-bottom",
+            "margin-left",
+            "margin-right",
+            "margin-top",
+            "mask",
+            "mask-clip",
+            "mask-composite",
+            "mask-image",
+            "mask-mode",
+            "mask-origin",
+            "mask-position",
+            "mask-repeat",
+            "mask-size",
+            "mask-type",
+            "max-height",
+            "max-width",
+            "min-height",
+            "min-width",
+            "mix-blend-mode",
+            "object-fit",
+            "object-position",
+            "opacity",
+            "order",
+            "orphans",
+            "outline",
+            "outline-color",
+            "outline-offset",
+            "outline-style",
+            "outline-width",
+            "overflow",
+            "overflow-wrap",
+            "overflow-x",
+            "overflow-y",
+            "padding",
+            "padding-bottom",
+            "padding-left",
+            "padding-right",
+            "padding-top",
+            "page-break-after",
+            "page-break-before",
+            "page-break-inside",
+            "perspective",
+            "perspective-origin",
+            "pointer-events",
+            "position",
+            "quotes",
+            "resize",
+            "right",
+            "row-gap",
+            "scroll-behavior",
+            "tab-size",
+            "table-layout",
+            "text-align",
+            "text-align-last",
+            "text-combine-upright",
+            "text-decoration",
+            "text-decoration-color",
+            "text-decoration-line",
+            "text-decoration-skip",
+            "text-decoration-style",
+            "text-indent",
+            "text-justify",
+            "text-orientation",
+            "text-overflow",
+            "text-shadow",
+            "text-transform",
+            "text-underline-position",
+            "top",
+            "transform",
+            "transform-origin",
+            "transform-style",
+            "transition",
+            "transition-delay",
+            "transition-duration",
+            "transition-property",
+            "transition-timing-function",
+            "unicode-bidi",
+            "user-select",
+            "vertical-align",
+            "visibility",
+            "white-space",
+            "widows",
+            "width",
+            "word-break",
+            "word-spacing",
+            "word-wrap",
+            "writing-mode",
+            "z-index"
+        };
+
+        /// <summary>
+        /// The default allowed CSS classes.
+        /// </summary>
+        public static ISet<string> DefaultAllowedClasses { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
The `HtmlSanitizer` is over thousand lines long and mixes the concerns of logic and default options, so refactor out the default options to a separate file.