### PR TITLE
Target net6.0 only for unit test

### DIFF
--- a/test/HtmlSanitizer.Tests/HtmlSanitizer.Tests.csproj
+++ b/test/HtmlSanitizer.Tests/HtmlSanitizer.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>HtmlSanitizer.Tests</AssemblyName>
     <PackageId>HtmlSanitizer.Tests</PackageId>

--- a/test/HtmlSanitizer.Tests/HtmlSanitizer.Tests.csproj
+++ b/test/HtmlSanitizer.Tests/HtmlSanitizer.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>HtmlSanitizer.Tests</AssemblyName>
     <PackageId>HtmlSanitizer.Tests</PackageId>


### PR DESCRIPTION
We do not need to target both net472 and net6.0 for the unit tests. Not targeting net472 allows the unit test to also run on Linux without Mono installed.