### PR TITLE
Rename namespace

### DIFF
--- a/src/HtmlSanitizer/EventArgs.cs
+++ b/src/HtmlSanitizer/EventArgs.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 
-namespace Ganss.XSS
+namespace Ganss.Xss
 {
     /// <summary>
     /// Provides data for the <see cref="HtmlSanitizer.PostProcessDom"/> event.

--- a/src/HtmlSanitizer/HtmlFormatter.cs
+++ b/src/HtmlSanitizer/HtmlFormatter.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Ganss.XSS
+namespace Ganss.Xss
 {
     /// <summary>
     /// HTML5 markup formatter. Identical to <see cref="HtmlMarkupFormatter"/> except for &lt; and &gt; which are

--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -12,7 +12,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 
-namespace Ganss.XSS
+namespace Ganss.Xss
 {
     /// <summary>
     /// Cleans HTML documents and fragments from constructs that can lead to <a href="https://en.wikipedia.org/wiki/Cross-site_scripting">XSS attacks</a>.

--- a/src/HtmlSanitizer/HtmlSanitizer.csproj
+++ b/src/HtmlSanitizer/HtmlSanitizer.csproj
@@ -21,7 +21,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/mganss/HtmlSanitizer</RepositoryUrl>
-    <RootNamespace>Ganss.XSS</RootNamespace>
+    <RootNamespace>Ganss.Xss</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\HtmlSanitizer.xml</DocumentationFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/HtmlSanitizer/HtmlSanitizerDefaults.cs
+++ b/src/HtmlSanitizer/HtmlSanitizerDefaults.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
-namespace Ganss.XSS
+namespace Ganss.Xss
 {
     /// <summary>
     /// Default options.

--- a/src/HtmlSanitizer/HtmlSanitizerOptions.cs
+++ b/src/HtmlSanitizer/HtmlSanitizerOptions.cs
@@ -2,7 +2,7 @@ using AngleSharp.Css.Dom;
 using System;
 using System.Collections.Generic;
 
-namespace Ganss.XSS
+namespace Ganss.Xss
 {
     /// <summary>
     /// Provides options to be used with <see cref="HtmlSanitizer"/>.

--- a/src/HtmlSanitizer/IHtmlSanitizer.cs
+++ b/src/HtmlSanitizer/IHtmlSanitizer.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
-namespace Ganss.XSS
+namespace Ganss.Xss
 {
     /// <summary>
     /// Enables an inheriting class to implement an HtmlSanitizer class, which cleans HTML documents and fragments

--- a/src/HtmlSanitizer/Iri.cs
+++ b/src/HtmlSanitizer/Iri.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace Ganss.XSS
+namespace Ganss.Xss
 {
     /// <summary>
     /// Represents an Internationalized Resource Identifier.

--- a/src/HtmlSanitizer/RemoveReason.cs
+++ b/src/HtmlSanitizer/RemoveReason.cs
@@ -1,4 +1,4 @@
-﻿namespace Ganss.XSS
+﻿namespace Ganss.Xss
 {
     /// <summary>
     /// List of reasons why something was identified to get removed from the HTML.

--- a/test/HtmlSanitizer.Benchmark/HtmlSanitizerBenchmark.cs
+++ b/test/HtmlSanitizer.Benchmark/HtmlSanitizerBenchmark.cs
@@ -1,6 +1,6 @@
 using BenchmarkDotNet.Attributes;
 
-namespace Ganss.XSS.Benchmark;
+namespace Ganss.Xss.Benchmark;
 
 [MemoryDiagnoser]
 public class HtmlSanitizerBenchmark

--- a/test/HtmlSanitizer.Benchmark/Program.cs
+++ b/test/HtmlSanitizer.Benchmark/Program.cs
@@ -1,4 +1,4 @@
 using BenchmarkDotNet.Running;
-using Ganss.XSS.Benchmark;
+using Ganss.Xss.Benchmark;
 
 BenchmarkSwitcher.FromAssembly(typeof(HtmlSanitizerBenchmark).Assembly).Run(args);

--- a/test/HtmlSanitizer.Tests/Tests.cs
+++ b/test/HtmlSanitizer.Tests/Tests.cs
@@ -16,7 +16,7 @@ using Xunit;
 // https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet#RULE_.232_-_Attribute_Escape_Before_Inserting_Untrusted_Data_into_HTML_Common_Attributes
 // and http://ha.ckers.org/xss.html
 
-namespace Ganss.XSS.Tests;
+namespace Ganss.Xss.Tests;
 
 public class HtmlSanitizerFixture
 {


### PR DESCRIPTION
Rename namespace from `Ganss.XSS` to `Ganss.Xss` as per the [Microsoft .NET Framework Design Guidelines Capitalization Conventions](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/capitalization-conventions).