### PR TITLE
Rewrite GetAllNodes to use a stack on the heap

### DIFF
--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -334,9 +334,9 @@ namespace Ganss.Xss
         /// </summary>
         /// <param name="dom">The root node.</param>
         /// <returns>All nested subnodes.</returns>
-        private static IEnumerable<INode> GetAllNodes(INode? dom)
+        private static IEnumerable<INode> GetAllNodes(INode dom)
         {
-            if (dom == null || dom.ChildNodes.Length == 0) yield break;
+            if (dom.ChildNodes.Length == 0) yield break;
             
             var s = new Stack<INode>();
             for (var i = dom.ChildNodes.Length - 1; i >= 0; i--)
@@ -447,7 +447,7 @@ namespace Ganss.Xss
         /// </summary>
         /// <param name="context">The node within which to remove comments.</param>
         /// <returns><c>true</c> if any comments were removed; otherwise, <c>false</c>.</returns>
-        private void RemoveComments(INode? context)
+        private void RemoveComments(INode context)
         {
             foreach (var comment in GetAllNodes(context).OfType<IComment>().ToList())
             {
@@ -522,7 +522,10 @@ namespace Ganss.Xss
                 }
             }
 
-            RemoveComments(context as INode);
+            if (context is INode node)
+            {
+                RemoveComments(node);
+            }
 
             DoPostProcess(dom, context as INode);
         }
@@ -596,16 +599,19 @@ namespace Ganss.Xss
             if (PostProcessNode != null)
             {
                 dom.Normalize();
-                var nodes = GetAllNodes(context).ToList();
-
-                foreach (var node in nodes)
+                
+                if (context != null)
                 {
-                    var e = new PostProcessNodeEventArgs(dom, node);
-                    OnPostProcessNode(e);
-                    if (e.ReplacementNodes.Any())
+                    var nodes = GetAllNodes(context).ToList();
+                    foreach (var node in nodes)
                     {
-                        ((IChildNode)node).Replace(e.ReplacementNodes.ToArray());
-                    }
+                        var e = new PostProcessNodeEventArgs(dom, node);
+                        OnPostProcessNode(e);
+                        if (e.ReplacementNodes.Any())
+                        {
+                            ((IChildNode)node).Replace(e.ReplacementNodes.ToArray());
+                        }
+                    }   
                 }
             }
 


### PR DESCRIPTION
`HtmlSanitizer.GetAllNodes()` uses the program stack to iterate on elements in the DOM, and when we try to parse a deeply nested email (a few thousand elements deep) we get a stack overflow exception. Because our app runs in IIS it has a very small stack size. However, even if we increase our stack size, we will still crash - we just need a bigger HTML document. And when we crash with stack overflow, the entire app goes down. 

See https://github.com/mganss/HtmlSanitizer/issues/417 as this is the same issue as we are having.

Even though HtmlSanitizer throws StackOverflowException, AngleSharp is still able to parse the HTML.

I have rewritten `GetAllNodes()` to use a stack on the heap to avoid stack overflows, so that if AngleSharp can parse then HtmlSanitizer can sanitize it. I don't think HtmlSanitizer rely on the ordering of the returned enumeration, but I have kept the depth-first ordering we got when using the recursive approach.

Note that there is the same issue with `StyleExtensions.GetStylesheets()` in AngleSharp that still cause HtmlSanitizer to crash when enumerating style sheets. I plan to send a PR to that repository as well.

I think existing unit tests has enough coverage for this method so I did not create any additional tests.