### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ More example code and a description of possible options can be found in the [Wik
 `bdi`,
 `big`,
 `blockquote`,
-`body`
+`body`,
 `br`,
 `button`,
 `caption`,


### PR DESCRIPTION
add missing comma

Try to split the default allowed tags by ", " on README, and only find 98 elements. And I find there are 99 tags when watch the allowed tags in property.
Then I find that we lost a comma between body and br