### PR TITLE
Added option to allow custom CSS properties (variables).

### DIFF
--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -99,6 +99,8 @@ namespace Ganss.Xss
             AllowedClasses = new HashSet<string>(options.AllowedCssClasses, StringComparer.OrdinalIgnoreCase);
             AllowedCssProperties = new HashSet<string>(options.AllowedCssProperties, StringComparer.OrdinalIgnoreCase);
             AllowedAtRules = new HashSet<CssRuleType>(options.AllowedAtRules);
+            AllowCssCustomProperties = options.AllowCssCustomProperties;
+            AllowDataAttributes = options.AllowDataAttributes;
         }
 
         /// <summary>

--- a/src/HtmlSanitizer/HtmlSanitizerOptions.cs
+++ b/src/HtmlSanitizer/HtmlSanitizerOptions.cs
@@ -43,5 +43,15 @@ namespace Ganss.Xss
         /// Gets or sets the HTML attributes that can contain a URI such as "href".
         /// </summary>
         public ISet<string> UriAttributes { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Allow all custom CSS properties (variables) prefixed with <c>--</c>.
+        /// </summary>
+        public bool AllowCssCustomProperties { get; set; }
+
+        /// <summary>
+        /// Allow all HTML5 data attributes; the attributes prefixed with <c>data-</c>.
+        /// </summary>
+        public bool AllowDataAttributes { get; set; }
     }
 }

--- a/test/HtmlSanitizer.Tests/Tests.cs
+++ b/test/HtmlSanitizer.Tests/Tests.cs
@@ -2903,7 +2903,7 @@ zqy1QY1kkPOuMvKWvvmFIwClI2393jVVcp91eda4+J+fIYDbfJa7RY5YcNrZhTuV//9k="">
             var waiting = numThreads;
             var methods = typeof(HtmlSanitizerTests).GetTypeInfo().GetMethods()
                 .Where(m => m.GetCustomAttributes(typeof(Xunit.FactAttribute), false).Cast<Xunit.FactAttribute>().Any(f => f.Skip == null))
-                .Where(m => m.Name != "ThreadTest" && m.Name != "HexColorTest");
+                .Where(m => m.Name != nameof(ThreadTest) && m.Name != nameof(HexColorTest));
             var threads = Shuffle(methods, random)
                 .Take(numThreads)
                 .Select(m => new Thread(() =>
@@ -3588,5 +3588,45 @@ zqy1QY1kkPOuMvKWvvmFIwClI2393jVVcp91eda4+J+fIYDbfJa7RY5YcNrZhTuV//9k="">
         sanitizer.AllowedTags.Remove("iframe");
         var sanitized = sanitizer.Sanitize(input);
         Assert.Equal("&lt;img&gt;&amp;lt;img&amp;gt;", sanitized);
+    }
+
+    [Fact]
+    public void AllowStyleAttributeCssCustomPropertiesTest()
+    {
+        var input = "<div style=\"--my-var: 1px\"></div>";
+        var sanitizer = new HtmlSanitizer { AllowCssCustomProperties = true };
+        sanitizer.AllowedTags.Remove("iframe");
+        var sanitized = sanitizer.Sanitize(input);
+        Assert.Equal("<div style=\"--my-var: 1px\"></div>", sanitized);
+    }
+
+    [Fact]
+    public void AllowStyleTagCssCustomPropertiesTest()
+    {
+        var input = "<style>:root { --my-var: 1px }</style>";
+        var sanitizer = new HtmlSanitizer { AllowCssCustomProperties = true };
+        sanitizer.AllowedTags.Add("style");
+        var sanitized = sanitizer.Sanitize(input);
+        Assert.Equal("<style>:root { --my-var: 1px }</style>", sanitized);
+    }
+
+    [Fact]
+    public void DisallowStyleAttributeCssCustomPropertiesTest()
+    {
+        var input = "<div style=\"--my-var: 1px\"></div>";
+        var sanitizer = new HtmlSanitizer();
+        sanitizer.AllowedTags.Remove("iframe");
+        var sanitized = sanitizer.Sanitize(input);
+        Assert.Equal("<div></div>", sanitized);
+    }
+
+    [Fact]
+    public void DisallowStyleTagCssCustomPropertiesTest()
+    {
+        var input = "<style>:root { --my-var: 1px }</style>";
+        var sanitizer = new HtmlSanitizer();
+        sanitizer.AllowedTags.Add("style");
+        var sanitized = sanitizer.Sanitize(input);
+        Assert.Equal("<style>:root { }</style>", sanitized);
     }
 }


### PR DESCRIPTION
I added an option to allow custom CSS properties (variables) without specifying all the potential options (ie, allow all `--*` css properties)

I ran into an issue where I wanted to accept CSS variables, but based on the execution order, it would leave the value part unsanitized. The `SanitizeStyleDeclaration` would reject the name immediately, and while it can be cancelled in the `OnRemovingStyle` event, that leaves the value part unevaluated.

With this update, evaluation of the property name can be customized by overriding the `IsAllowedCssProperty` method. The default handling checks the `AllowedCssProperties`, same as before. Then if the `AllowCssCustomProperties` flag is true, it will allow any property beginning with `--`. This method can be override if developers want to refine the prefix.

It allows css variables both in `<style>` tags (if allowed) as well as tag `style` attributes (`<div style="--my-var:1px"></div>`)

The flag can be set like this:
```csharp
var sanitizer = new HtmlSanitizer { AllowCssCustomProperties = true };
```

