### PR TITLE
Introduced net8.0 TFM

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ HtmlSanitizer
 
 [![netstandard2.0](https://img.shields.io/badge/netstandard-2.0-brightgreen.svg)](https://img.shields.io/badge/netstandard-2.0-brightgreen.svg)
 [![net46](https://img.shields.io/badge/net-461-brightgreen.svg)](https://img.shields.io/badge/net-461-brightgreen.svg)
+[![net8.0](https://img.shields.io/badge/net-8.0-brightgreen.svg)](https://img.shields.io/badge/net-461-brightgreen.svg)
 
 HtmlSanitizer is a .NET library for cleaning HTML fragments and documents from constructs that can lead to [XSS attacks](https://en.wikipedia.org/wiki/Cross-site_scripting).
 It uses [AngleSharp](https://github.com/AngleSharp/AngleSharp) to parse, manipulate, and render HTML and CSS.

--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -874,7 +874,7 @@ public class HtmlSanitizer : IHtmlSanitizer
         if (iri != null && !iri.IsAbsolute && !string.IsNullOrEmpty(baseUrl))
         {
             // resolve relative URI
-            if (Uri.TryCreate(baseUrl, UriKind.Absolute, out Uri baseUri))
+            if (Uri.TryCreate(baseUrl, UriKind.Absolute, out Uri? baseUri))
             {
                 try
                 {

--- a/src/HtmlSanitizer/HtmlSanitizer.csproj
+++ b/src/HtmlSanitizer/HtmlSanitizer.csproj
@@ -42,6 +42,12 @@
     <PackageReference Include="AngleSharp" Version="[0.17.1]" />
     <PackageReference Include="AngleSharp.Css" Version="[0.17.0]" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461'">
+    <PackageReference Include="System.Collections.Immutable" Version="9.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Collections.Immutable" Version="9.0.1" />
   </ItemGroup>
 

--- a/src/HtmlSanitizer/HtmlSanitizer.csproj
+++ b/src/HtmlSanitizer/HtmlSanitizer.csproj
@@ -10,7 +10,7 @@
     <FileVersion>$(AppVeyor_Build_Version).0</FileVersion>
     <PackageVersion>$(AppVeyor_Build_Version)</PackageVersion>
     <Authors>Michael Ganss</Authors>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>HtmlSanitizer</AssemblyName>
     <AssemblyOriginatorKeyFile>HtmlSanitizer.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Introduced net8.0 TFM to avoid PackageReference to System.Collections.Immutable, as it is package-provided (since NET6)