### PR TITLE
System value tuple net462 only

### DIFF
--- a/src/HtmlSanitizer/HtmlSanitizer.csproj
+++ b/src/HtmlSanitizer/HtmlSanitizer.csproj
@@ -53,11 +53,6 @@
     <PackageReference Include="System.Collections.Immutable" Version="9.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46'">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
   <ItemGroup>
     <None Include="../../README.md" Pack="true" PackagePath="" />
   </ItemGroup>

--- a/src/HtmlSanitizer/HtmlSanitizer.csproj
+++ b/src/HtmlSanitizer/HtmlSanitizer.csproj
@@ -43,11 +43,11 @@
     <PackageReference Include="AngleSharp" Version="[0.17.1]" />
     <PackageReference Include="AngleSharp.Css" Version="[0.17.0]" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.Collections.Immutable" Version="9.0.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Collections.Immutable" Version="9.0.1" />


### PR DESCRIPTION
- Defined `System.ValueTuple` package reference as conditional for `net462` only to reduce package references for other TFMs
- Removed the `net46` conditional references to `System` and `Microsoft.CSharp` as they are both included by SDK and `net46` condition is always `false` with the current TFMs