### PR TITLE
Commit the changes for preparing the Sanitization report

### DIFF
--- a/src/HtmlSanitizer/ISanitizationReport.cs
+++ b/src/HtmlSanitizer/ISanitizationReport.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ganss.Xss
+{
+    /// <summary>  
+    /// Represents a report of sanitation actions performed on HTML content.  
+    /// </summary>  
+    public interface ISanitizationReport
+    {
+        /// <summary>  
+        /// Gets or sets the list of tags that were removed during sanitation.  
+        /// </summary>  
+        List<string> RemovedTags { get; set; }
+
+        /// <summary>  
+        /// Gets or sets the list of attributes that were removed during sanitation.  
+        /// </summary>  
+        List<string> RemovedAttributes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of CSS classes that were removed during sanitation.
+        /// </summary>
+        List<string> RemovedCssClass { get; set; }
+
+        /// <summary>  
+        /// Gets or sets the list of attributes that were modified during sanitation.  
+        /// </summary>  
+        List<string> ModifiedAttributes { get; set; }
+
+        /// <summary>  
+        /// Logs a tag that was removed during sanitation.  
+        /// </summary>  
+        /// <param name="tag">The name of the tag that was removed.</param>  
+        void LogRemovedTag(string tag);
+
+        /// <summary>  
+        /// Logs an attribute that was removed during sanitation.  
+        /// </summary>  
+        /// <param name="tag">The name of the tag containing the attribute.</param>  
+        /// <param name="attr">The name of the attribute that was removed.</param>  
+        void LogRemovedAttr(string tag, string attr);
+
+        /// <summary>  
+        /// Logs an attribute that was modified during sanitation.  
+        /// </summary>  
+        /// <param name="tag">The name of the tag containing the attribute.</param>  
+        /// <param name="attr">The name of the attribute that was modified.</param>  
+        void LogModifiedAttr(string tag, string attr);
+
+        /// <summary>
+        /// Logs a CSS class that was removed during sanitation.
+        /// </summary>
+        /// <param name="tag">The name of the tag containing the CSS class.</param>
+        /// <param name="attr">The name of the CSS class that was removed.</param>
+        void LogRemovedCssClass(string tag, string cssclass);
+    }
+}

--- a/src/HtmlSanitizer/SanitizationReport.cs
+++ b/src/HtmlSanitizer/SanitizationReport.cs
@@ -1,0 +1,74 @@
+﻿using AngleSharp.Dom;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ganss.Xss
+{
+    /// <summary>
+    /// Represents a report of sanitation actions performed on HTML content.
+    /// </summary>
+    public class SanitizationReport : ISanitizationReport
+    {
+        /// <summary>
+        /// Gets or sets the list of tags that were removed during sanitation.
+        /// </summary>
+        public List<string> RemovedTags { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the list of attributes that were removed during sanitation.
+        /// </summary>
+        public List<string> RemovedAttributes { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the list of attributes that were modified during sanitation.
+        /// </summary>
+        public List<string> ModifiedAttributes { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets the list of CSS classes that were removed during sanitation.
+        /// </summary>
+        public List<string> RemovedCssClass { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Logs a removed attribute for a specific tag.
+        /// </summary>
+        /// <param name="tag">The tag containing the removed attribute.</param>
+        /// <param name="attr">The name of the removed attribute.</param>
+        public void LogRemovedAttr(string tag, string attr)
+        {
+            RemovedAttributes.Add($"{tag} - [{attr}]");
+        }
+
+        /// <summary>
+        /// Logs a removed tag.
+        /// </summary>
+        /// <param name="tag">The name of the removed tag.</param>
+        public void LogRemovedTag(string tag)
+        {
+            RemovedTags.Add(tag);
+        }
+
+        /// <summary>
+        /// Logs a modified attribute for a specific tag.
+        /// </summary>
+        /// <param name="tag">The tag containing the modified attribute.</param>
+        /// <param name="attr">The name of the modified attribute.</param>
+        public void LogModifiedAttr(string tag, string attr)
+        {
+            ModifiedAttributes.Add($"{tag} - [{attr}]");
+        }
+
+        /// <summary>
+        /// Logs a removed CSS class for a specific tag.
+        /// </summary>
+        /// <param name="tag">The tag containing the removed CSS class.</param>
+        /// <param name="cssclass">The name of the removed CSS class.</param>
+        public void LogRemovedCssClass(string tag, string cssclass)
+        {
+            RemovedCssClass.Add($"{tag} - [{cssclass}]");
+        }
+    }
+}

--- a/src/HtmlSanitizer/SanitizationReportLogger.cs
+++ b/src/HtmlSanitizer/SanitizationReportLogger.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ganss.Xss
+{
+    /// <summary>
+    /// Provides functionality to generate a log for a sanitization report.
+    /// </summary>
+    public static class SanitizationReportLogger
+    {
+        /// <summary>
+        /// Generates a detailed log based on the provided sanitization report.
+        /// </summary>
+        /// <param name="report">The sanitization report containing details of removed or modified elements.</param>
+        /// <returns>A string representation of the sanitization report log.</returns>
+        public static string GenerateLog(ISanitizationReport report)
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine("Sanitization Report");
+            sb.AppendLine(new string('-', 40));
+
+            // Removed Tags
+            if (report.RemovedTags.Any())
+            {
+                sb.AppendLine("Removed Tags:");
+                foreach (var tag in report.RemovedTags.Distinct())
+                    sb.AppendLine($"  - <{tag}>");
+            }
+            else
+            {
+                sb.AppendLine("No tags were removed.");
+            }
+
+            sb.AppendLine();
+
+            // Removed Attributes
+            if (report.RemovedAttributes.Any())
+            {
+                sb.AppendLine("Removed Attributes:");
+                foreach (var attr in report.RemovedAttributes.Distinct())
+                    sb.AppendLine($"  - {attr}");
+            }
+            else
+            {
+                sb.AppendLine("No attributes were removed.");
+            }
+
+            sb.AppendLine();
+
+            // Removed Css Class
+            if (report.RemovedCssClass.Any())
+            {
+                sb.AppendLine("Removed CSS Class:");
+                foreach (var attr in report.RemovedCssClass.Distinct())
+                    sb.AppendLine($"  - {attr}");
+            }
+            else
+            {
+                sb.AppendLine("No css class were removed.");
+            }
+
+            sb.AppendLine();
+            // Modified Attributes
+            if (report.ModifiedAttributes.Any())
+            {
+                sb.AppendLine("Modified Attributes:");
+                foreach (var attr in report.ModifiedAttributes.Distinct())
+                    sb.AppendLine($"  - {attr}");
+            }
+            else
+            {
+                sb.AppendLine("No attributes were modified.");
+            }
+
+            sb.AppendLine(new string('-', 40));
+
+            return sb.ToString();
+        }
+    }
+
+}

--- a/test/HtmlSanitizer.Tests/Tests.cs
+++ b/test/HtmlSanitizer.Tests/Tests.cs
@@ -873,6 +873,22 @@ S
         Assert.Equal(expected, actual, ignoreCase: true);
     }
 
+    [Fact]
+    public void AnchorTagStyleExpressionXssWithReportTest()
+    {
+        // Arrange
+        var sanitizer = Sanitizer;
+
+        // Act
+        string htmlFragment = "exp/*<A STYLE='no\\xss:noxss(\"*//*\");xss:&#101;x&#x2F;*XSS*//*/*/pression(alert(\"XSS\"))'>";
+        string actual = sanitizer.Sanitize(htmlFragment, out var report);
+        //To generate structured log output
+        string logOutput = SanitizationReportLogger.GenerateLog(report);
+        // Assert
+        string expected = "exp/*<a></a>";
+        Assert.Equal(expected, actual, ignoreCase: true);
+    }
+
     /// <summary>
     /// A test for Base tag
     /// Example <!-- <BASE HREF="javascript:alert('XSS');//"> -->
@@ -980,6 +996,24 @@ S
         // Act
         string htmlFragment = "<XML ID=\"xss\"><I><B>&lt;IMG SRC=\"javas<!-- -->cript:alert('XSS')\"&gt;</B></I></XML><SPAN DATASRC=\"#xss\" DATAFLD=\"B\" DATAFORMATAS=\"HTML\"></SPAN>";
         string actual = sanitizer.Sanitize(htmlFragment);
+
+        // Assert
+        string expected = "<SPAN></SPAN>";
+        Assert.Equal(expected, actual, ignoreCase: true);
+    }
+
+    [Fact]
+    public void XmlWithCommentObfuscationXssWithReportTest()
+    {
+        // Arrange
+        var sanitizer = Sanitizer;
+
+        // Act
+        string htmlFragment = "<XML ID=\"xss\"><I><B>&lt;IMG SRC=\"javas<!-- -->cript:alert('XSS')\"&gt;</B></I></XML><SPAN DATASRC=\"#xss\" DATAFLD=\"B\" DATAFORMATAS=\"HTML\"></SPAN>";
+        string actual = sanitizer.Sanitize(htmlFragment, out var report);
+
+        //To generate structured log output
+        string logOutput = SanitizationReportLogger.GenerateLog(report);
 
         // Assert
         string expected = "<SPAN></SPAN>";
@@ -1656,6 +1690,24 @@ S
 
         Assert.Equal(expected, actual, ignoreCase: true);
     }
+
+
+    [Fact]
+    public void DisallowedAttributeWithReportTest()
+    {
+        var sanitizer = Sanitizer;
+
+        var html = @"<div bla=""test"">Test</div>";
+        var actual = sanitizer.Sanitize(html, out var report);
+
+        //To generate structured log output
+        string logOutput = SanitizationReportLogger.GenerateLog(report);
+
+        var expected = @"<div>Test</div>";
+
+        Assert.Equal(expected, actual, ignoreCase: true);
+    }
+
 
     /// <summary>
     /// Tests sanitization of attributes that contain a URL.
@@ -2998,6 +3050,28 @@ zqy1QY1kkPOuMvKWvvmFIwClI2393jVVcp91eda4+J+fIYDbfJa7RY5YcNrZhTuV//9k="">
 
         var html = @"<div class=""good bad"">Test</div>";
         var actual = sanitizer.Sanitize(html);
+
+        // Assert
+        Assert.Equal(@"<div>Test</div>", actual);
+    }
+
+
+    [Fact]
+    public void RemoveClassAttributeIfEmptyWithReportTest()
+    {
+        var options = new HtmlSanitizerOptions
+        {
+            AllowedTags = new HashSet<string> { "div" },
+            AllowedAttributes = new HashSet<string> { "class" },
+            AllowedCssClasses = new HashSet<string> { "other" },
+        };
+        var sanitizer = new HtmlSanitizer(options);
+
+        var html = @"<div class=""good bad"">Test</div>";
+        var actual = sanitizer.Sanitize(html, out var report);
+        //To generate structured log output
+        string logOutput = SanitizationReportLogger.GenerateLog(report);
+
 
         // Assert
         Assert.Equal(@"<div>Test</div>", actual);


### PR DESCRIPTION

# ✨ Feature: Structured Sanitization Report

## 📝 Summary

This update introduces a **structured `SanitizationReport`** that captures and exposes details about what elements were removed or altered during HTML sanitization. This is essential for debugging, auditing, or logging HTML sanitization behavior, especially when dealing with user-generated content.

---

## ✅ Purpose

When sanitizing user-supplied HTML, it’s often helpful to **know what was removed or modified**, especially for:

- **Security audits** (e.g., tracking blocked scripts or unsafe links)
- **Debugging** unexpected behavior or layout issues
- **User feedback** (e.g., "Your content contained disallowed HTML")

This feature provides a structured report containing:
- Removed HTML tags
- Removed attributes
- Removed CSS classes
- Modified attributes

---

### `SanitizationReport` (Implementation)

This class stores logs of all sanitization actions taken during DOM processing. It can be injected into the sanitizer as an `out` parameter.

### `SanitizationReportLogger`

Helper class that converts the raw report into a readable, structured log output.

---

## 🔍 Example Usage

```csharp
var sanitizer = new HtmlSanitizer(options);
var html = @"<div class=""good bad"">Test</div>";
var actual = sanitizer.Sanitize(html, out var report);
//To generate structured log output
string logOutput = SanitizationReportLogger.GenerateLog(report);

Console.WriteLine(logOutput);
```

---

## 📄 Sample Output

```
Sanitization Report
----------------------------------------
No tags were removed.

Removed Attributes:
  - DIV - [class]

Removed CSS Class:
  - DIV - [good]
  - DIV - [bad]

No attributes were modified.
----------------------------------------
```

---

## 🚀 Benefits

- **Improved Transparency**: Helps devs and reviewers understand how and why sanitization decisions were made.
- **Debugging UX**: Allows tracing back unexpected rendering changes after sanitization.
- **Security Monitoring**: Logs unsafe or blocked content for security reviews.
---
