### PR TITLE
Preserve whitespace when rewriting url() in CSS values (fixes #629)

### DIFF
--- a/src/HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/HtmlSanitizer/HtmlSanitizer.cs
@@ -800,9 +800,13 @@ public class HtmlSanitizer : IHtmlSanitizer
                 continue;
             }
 
-            val = WhitespaceRegex.Replace(val, string.Empty);
+            // The whitespace-stripped copy is used only to detect (possibly whitespace-obfuscated) url() constructs.
+            // The value written back is rebuilt from the original so that spacing between tokens is preserved.
+            var strippedVal = WhitespaceRegex.Replace(val, string.Empty);
 
-            var urls = CssUrl.Matches(val).Cast<Match>().Select(m => (Match: m, Url: SanitizeUrl(element, m.Groups[2].Value, baseUrl))).ToList();
+            var urls = CssUrl.Matches(strippedVal).Cast<Match>()
+                .Select(m => (Match: m, Url: SanitizeUrl(element, m.Groups[2].Value, baseUrl)))
+                .ToList();
 
             if (urls.Count > 0)
             {
@@ -810,24 +814,33 @@ public class HtmlSanitizer : IHtmlSanitizer
                     removeStyles.Add(new Tuple<ICssProperty, RemoveReason>(style, RemoveReason.NotAllowedUrlValue));
                 else
                 {
+                    // Prefer rebuilding against the original value so whitespace is preserved. Only fall
+                    // back to the stripped value if the url tokens don't line up (which can happen when
+                    // whitespace was obfuscating the url() construct).
+                    var originalMatches = CssUrl.Matches(val).Cast<Match>().ToList();
+                    var useOriginal = originalMatches.Count == urls.Count;
+                    var baseValue = useOriginal ? val : strippedVal;
+                    var matches = useOriginal ? originalMatches : urls.Select(u => u.Match).ToList();
+
                     var sb = new StringBuilder();
                     var ix = 0;
 
-                    foreach (var url in urls)
+                    for (var j = 0; j < matches.Count; j++)
                     {
-                        sb.Append(val, ix, url.Match.Index - ix);
+                        var match = matches[j];
+                        sb.Append(baseValue, ix, match.Index - ix);
                         sb.Append("url(");
-                        sb.Append(url.Match.Groups[1].Value);
-                        sb.Append(url.Url);
-                        sb.Append(url.Match.Groups[3].Value);
-                        ix = url.Match.Index + url.Match.Length;
+                        sb.Append(match.Groups[1].Value);
+                        sb.Append(urls[j].Url);
+                        sb.Append(match.Groups[3].Value);
+                        ix = match.Index + match.Length;
                     }
 
-                    sb.Append(val, ix, val.Length - ix);
+                    sb.Append(baseValue, ix, baseValue.Length - ix);
 
                     var s = sb.ToString();
 
-                    if (s != val)
+                    if (s != baseValue)
                     {
                         if (key != style.Name)
                         {

--- a/test/HtmlSanitizer.Tests/Tests.cs
+++ b/test/HtmlSanitizer.Tests/Tests.cs
@@ -1884,6 +1884,26 @@ rl(javascript:alert(""foo""))'>";
         Assert.Equal(@"<div style=""margin: 10px 20px"">x</div>", sanitizer.Sanitize(html, baseUrl));
     }
 
+    // Covers the fallback branch in SanitizeStyleDeclaration where the whitespace-stripped value and the
+    // original value yield a different number of url() matches.
+    [Fact]
+    public void SanitizeStyleUrlWhitespaceBeforeParenFallbackTest()
+    {
+        const string baseUrl = "https://cdn.example.com/assets/";
+        var sanitizer = new HtmlSanitizer
+        {
+            AllowCssCustomProperties = true
+        };
+
+        var html = @"<div style=""--logo: url (pic.png)"">x</div>";
+        var actual = sanitizer.Sanitize(html, baseUrl);
+        Assert.Equal(@"<div style=""--logo: url(https://cdn.example.com/assets/pic.png)"">x</div>", actual);
+
+        html = @"<div style=""--logo: url (javascript:alert(1))"">x</div>";
+        actual = sanitizer.Sanitize(html, baseUrl);
+        Assert.Equal(@"<div>x</div>", actual);
+    }
+
     [Fact]
     public void SanitizeRemoveSrcJavascriptTest()
     {

--- a/test/HtmlSanitizer.Tests/Tests.cs
+++ b/test/HtmlSanitizer.Tests/Tests.cs
@@ -1848,6 +1848,42 @@ rl(javascript:alert(""foo""))'>";
         Assert.Equal(@"<div style=""margin: 10px 20px""></div>", sanitizer.Sanitize(html), ignoreCase: true);
     }
 
+    // Regression test for whitespace being stripped from CSS values that contain a rewritten url()
+    [Fact]
+    public void SanitizeStyleUrlPreservesWhitespaceTest()
+    {
+        const string baseUrl = "https://cdn.example.com/assets/";
+        var sanitizer = new HtmlSanitizer { AllowCssCustomProperties = true };
+
+        // A CSS variable holding a composite value.
+        var html = @"<div style=""--panel-bg: #fff url(texture.png) repeat"">x</div>";
+        var actual = sanitizer.Sanitize(html, baseUrl);
+        Assert.Equal(@"<div style=""--panel-bg: #fff url(https://cdn.example.com/assets/texture.png) repeat"">x</div>", actual);
+        Assert.DoesNotContain("#fffurl", actual);
+
+        // A variable holding a list of image URLs keeps its comma separator and resolves both.
+        html = @"<div style=""--carousel-arrows: url(prev.svg), url(next.svg)"">x</div>";
+        actual = sanitizer.Sanitize(html, baseUrl);
+        Assert.Equal(@"<div style=""--carousel-arrows: url(https://cdn.example.com/assets/prev.svg), url(https://cdn.example.com/assets/next.svg)"">x</div>", actual);
+
+        // A vendor property is kept verbatim.
+        sanitizer.AllowedCssProperties.Add("-webkit-box-reflect");
+        html = @"<div style=""-webkit-box-reflect: below 2px url(reflect.png)"">x</div>";
+        actual = sanitizer.Sanitize(html, baseUrl);
+        Assert.Equal(@"<div style=""-webkit-box-reflect: below 2px url(https://cdn.example.com/assets/reflect.png)"">x</div>", actual);
+        Assert.DoesNotContain("2pxurl", actual);
+
+        // Standard shorthands keep working.
+        html = @"<div style=""background: #fff url(texture.png) repeat"">x</div>";
+        actual = sanitizer.Sanitize(html, baseUrl);
+        Assert.Contains("https://cdn.example.com/assets/texture.png", actual);
+        Assert.Contains(" repeat", actual);
+
+        // Values without url() are unaffected.
+        html = @"<div style=""margin: 10px 20px"">x</div>";
+        Assert.Equal(@"<div style=""margin: 10px 20px"">x</div>", sanitizer.Sanitize(html, baseUrl));
+    }
+
     [Fact]
     public void SanitizeRemoveSrcJavascriptTest()
     {
@@ -2529,7 +2565,7 @@ rl(javascript:alert(""foo""))'>";
         {
             AllowedTags = new HashSet<string> { "div" },
             AllowedAttributes = new HashSet<string> { "class" },
-            AllowedCssClasses  = new HashSet<string> { "good" },
+            AllowedCssClasses = new HashSet<string> { "good" },
         };
         RemoveReason? reason = null;
         string removedClass = null;
@@ -2555,7 +2591,7 @@ rl(javascript:alert(""foo""))'>";
         {
             AllowedTags = new HashSet<string> { "div" },
             AllowedAttributes = new HashSet<string> { "class" },
-            AllowedCssClasses  = new HashSet<string> { "other" },
+            AllowedCssClasses = new HashSet<string> { "other" },
         };
         RemoveReason? reason = null;
         string attributeName = null;
@@ -2992,7 +3028,7 @@ zqy1QY1kkPOuMvKWvvmFIwClI2393jVVcp91eda4+J+fIYDbfJa7RY5YcNrZhTuV//9k="">
         {
             AllowedTags = new HashSet<string> { "div" },
             AllowedAttributes = new HashSet<string> { "class" },
-            AllowedCssClasses  = new HashSet<string> { "other" },
+            AllowedCssClasses = new HashSet<string> { "other" },
         };
         var sanitizer = new HtmlSanitizer(options);
 
@@ -3713,16 +3749,20 @@ zqy1QY1kkPOuMvKWvvmFIwClI2393jVVcp91eda4+J+fIYDbfJa7RY5YcNrZhTuV//9k="">
     [Fact]
     public void FilterUrlDuplicateTest()
     {
+        const string baseUrl = "https://cdn.example.com/assets/";
+
         var sanitizer = new HtmlSanitizer();
 
         var count = 0;
         sanitizer.FilterUrl += (_, _) => count++;
 
         // A single background image with one url().
-        sanitizer.Sanitize(
-            @"<div style=""background-image: url(logo.png)"">Hello</div>",
-            "https://cdn.example.com/assets/");
-
+        sanitizer.Sanitize(@"<div style=""background-image: url(logo.png)"">x</div>", baseUrl);
         Assert.Equal(1, count);
+
+        // Two url()s in one value (multiple background images) fire once each - twice in total.
+        count = 0;
+        sanitizer.Sanitize(@"<div style=""background-image: url(a.png), url(b.png)"">x</div>", baseUrl);
+        Assert.Equal(2, count);
     }
 }


### PR DESCRIPTION
Fixes #629

`HtmlSanitizer.SanitizeStyleDeclaration` removes **all** whitespace from a CSS declaration value and writes that stripped string back whenever a `url()` inside it is rewritten (a relative URL resolved against a `baseUrl`).

## Root cause

In `HtmlSanitizer.SanitizeStyleDeclaration`, the declaration value has all whitespace removed:

```csharp
val = WhitespaceRegex.Replace(val, string.Empty);
```

This stripped string is used for URL detection **and** is then used to build the string written back into the style (`setStyles[key] = s;`) whenever a URL inside it changes.

## Suggested fix

Use the whitespace-stripped copy **only** to detect `url()` constructs, and rebuild the value written back from the **original** (un-stripped) value, replacing just the URL tokens so spacing is preserved. Fall back to the stripped value only if the URL tokens don't line up (whitespace-obfuscated `url()`), where spacing is irrelevant anyway.
