### PR TITLE
docs: add XML code usage examples for HtmlSanitizerOptions properties

### DIFF
--- a/src/HtmlSanitizer/HtmlSanitizerOptions.cs
+++ b/src/HtmlSanitizer/HtmlSanitizerOptions.cs
@@ -47,10 +47,20 @@ public class HtmlSanitizerOptions
     /// <summary>
     /// Allow all custom CSS properties (variables) prefixed with <c>--</c>.
     /// </summary>
+    /// <example>
+    /// <code>
+    /// var options = new HtmlSanitizerOptions { AllowCssCustomProperties = true };
+    /// </code>
+    /// </example>
     public bool AllowCssCustomProperties { get; set; }
 
     /// <summary>
     /// Allow all HTML5 data attributes; the attributes prefixed with <c>data-</c>.
     /// </summary>
+    /// <example>
+    /// <code>
+    /// var options = new HtmlSanitizerOptions { AllowDataAttributes = true };
+    /// </code>
+    /// </example>
     public bool AllowDataAttributes { get; set; }
 }


### PR DESCRIPTION
### Summary
Adds XML `<example>` code blocks to `AllowCssCustomProperties` and `AllowDataAttributes` in `HtmlSanitizerOptions.cs` to show quick IntelliSense code usage.