### PR TITLE
Add regression tests for #587

### DIFF
--- a/test/HtmlSanitizer.Tests/Tests.cs
+++ b/test/HtmlSanitizer.Tests/Tests.cs
@@ -3765,6 +3765,44 @@ zqy1QY1kkPOuMvKWvvmFIwClI2393jVVcp91eda4+J+fIYDbfJa7RY5YcNrZhTuV//9k="">
         Assert.Equal(@"<div style=""height: 0; background-image: url(&quot;https://example.com/1.jpg&quot;), url(&quot;https://example.com/2.jpg&quot;), url(&quot;https://example.com/3.jpg&quot;); display: none""></div>", sanitized);
     }
 
+    // A duplicate declaration must not override an earlier !important one, in a style element
+    // or in a style attribute. Fixed upstream in AngleSharp.Css 1.0.1,
+    // see https://github.com/AngleSharp/AngleSharp.Css/issues/193
+    [Fact]
+    public void Number587StyleElementTest()
+    {
+        // see https://github.com/mganss/HtmlSanitizer/issues/587
+        var sanitizer = new HtmlSanitizer(new HtmlSanitizerOptions
+        {
+            AllowedTags = new HashSet<string> { "style" },
+            AllowedAtRules = new HashSet<CssRuleType> { CssRuleType.Style },
+            AllowedCssProperties = new HashSet<string> { "font-size", "padding", "padding-bottom", "padding-left", "padding-right", "padding-top" }
+        });
+
+        var html = "<style>.someClass { padding: 20px !important; font-size: 20px; padding: 0 }</style>";
+        var sanitized = sanitizer.Sanitize(html);
+
+        Assert.Equal("<style>.someClass { padding: 20px !important; font-size: 20px }</style>", sanitized);
+    }
+
+    [Fact]
+    public void Number587StyleAttributeTest()
+    {
+        // see https://github.com/mganss/HtmlSanitizer/issues/587
+        var sanitizer = new HtmlSanitizer(new HtmlSanitizerOptions
+        {
+            AllowedTags = new HashSet<string> { "p" },
+            AllowedAttributes = new HashSet<string> { "style" },
+            AllowedAtRules = new HashSet<CssRuleType> { CssRuleType.Style },
+            AllowedCssProperties = new HashSet<string> { "font-size", "padding", "padding-bottom", "padding-left", "padding-right", "padding-top" }
+        });
+
+        var html = @"<p style=""padding: 20px !important; font-size: 20px; padding: 0"">Test</p>";
+        var sanitized = sanitizer.Sanitize(html);
+
+        Assert.Equal(@"<p style=""padding: 20px !important; font-size: 20px"">Test</p>", sanitized);
+    }
+
     [Fact]
     public void BypassTest()
     {


### PR DESCRIPTION
Issue #587 (`!important` declaration dropped when a duplicate non-important declaration follows it) no longer reproduces on `master`. The root cause was upstream in AngleSharp.Css (AngleSharp/AngleSharp.Css#193), and the fix shipped in AngleSharp.Css 1.0.1, which this repo picked up in the "Update NuGet packages" commit.

This adds two regression tests covering both cases from the issue, so a future AngleSharp bump can't silently reintroduce it:

- `Number587StyleElementTest` — the `<style>` element case
- `Number587StyleAttributeTest` — the inline `style` attribute case

Both assert that `padding: 20px !important` survives and the later `padding: 0` is dropped, matching browser cascade behaviour.

Verified failing before the AngleSharp.Css 1.0.1 bump and passing on current `master`; full suite is 322/322 green.

Note: the allow-lists include the `padding-*` longhands as well as the `padding` shorthand, because the sanitizer operates on the expanded declarations — allowing only the shorthand strips padding entirely and the test would pass for the wrong reason.