### PR TITLE
Add benchmark for a style-heavy document

### DIFF
--- a/test/HtmlSanitizer.Benchmark/HtmlSanitizerBenchmark.cs
+++ b/test/HtmlSanitizer.Benchmark/HtmlSanitizerBenchmark.cs
@@ -6,15 +6,24 @@ namespace Ganss.Xss.Benchmark;
 public class HtmlSanitizerBenchmark
 {
     private HtmlSanitizer _sanitizer = null!;
+    private HtmlSanitizer _styleSheetSanitizer = null!;
     private string _googleFileContent = null!;
     private string _largeFileContent = null!;
+    private string _emailFileContent = null!;
 
     [GlobalSetup]
     public void GlobalSetup()
     {
         _googleFileContent = File.ReadAllText("google.html");
         _largeFileContent = File.ReadAllText("ecmascript.html");
+        _emailFileContent = File.ReadAllText("email.html");
         _sanitizer = new HtmlSanitizer();
+
+        // <style> is not an allowed tag by default, so the tag is dropped before its content is
+        // ever looked at. Allowing it is what puts SanitizeStyleSheets - and the CSS parsing and
+        // regex work behind it - on the measured path.
+        _styleSheetSanitizer = new HtmlSanitizer();
+        _styleSheetSanitizer.AllowedTags.Add("style");
     }
 
     /// <summary>
@@ -42,5 +51,40 @@ public class HtmlSanitizerBenchmark
     public void SanitizeLarge()
     {
         _sanitizer.Sanitize(_largeFileContent);
+    }
+
+    /// <summary>
+    /// A newsletter is style-heavy: the work is CSS rather than DOM.
+    /// </summary>
+    /// <remarks>
+    /// The other documents leave the CSS path almost unmeasured - ECMAScript has no styled element
+    /// at all and Google has eight of 309 - even though sanitizing a style attribute costs far more
+    /// per byte than sanitizing ordinary markup. HTML email is where that case really arises, since
+    /// mail clients strip stylesheets and templates inline everything instead.
+    /// <para>
+    /// email.html is generated rather than taken from a real campaign, so that nothing
+    /// third-party is vendored in, but its shape is calibrated against a real responsive template
+    /// (Cerberus): about 45% of elements carry a style attribute, averaging 3.3 declarations each,
+    /// drawn from the property mix that template actually uses - margin, font-size, line-height,
+    /// color, padding, font-family. Values differ per element on purpose; repeating one string
+    /// would let the CSS parser cache its way to a number no real document would produce. A
+    /// minority carry background-image: url(...), which is kept a minority because the reference
+    /// template has none inline, and over-representing it would flatter any change aimed at URL
+    /// handling.
+    /// </para>
+    /// </remarks>
+    [Benchmark]
+    public void SanitizeEmail()
+    {
+        _sanitizer.Sanitize(_emailFileContent);
+    }
+
+    /// <summary>
+    /// The same newsletter with stylesheets kept, which is what exercises SanitizeStyleSheets.
+    /// </summary>
+    [Benchmark]
+    public void SanitizeEmailWithStyleSheets()
+    {
+        _styleSheetSanitizer.Sanitize(_emailFileContent);
     }
 }

--- a/test/HtmlSanitizer.Benchmark/email.html
+++ b/test/HtmlSanitizer.Benchmark/email.html
@@ -1,0 +1,841 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Monthly Digest</title>
+<style>
+  body { margin: 0 !important; padding: 0 !important; -webkit-text-size-adjust: 100%; }
+  table { border-collapse: collapse !important; mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+  img { border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none; }
+  .m0 { line-height: 187%; margin: 20px 15px; border: 1px solid #9fe3e8; max-width: 393px; line-height: 154%; text-decoration: none; }
+  .m1 { font-weight: normal; background-color: #4e1a1c; letter-spacing: 0.5px; margin: 25px 15px; margin: 18px 18px; }
+  .m2 { line-height: 186%; border-radius: 9px; padding: 22px 28px; background-color: #6f6adf; text-align: left; }
+  .m3 { max-width: 303px; background-color: #a68d0c; border: 1px solid #109755; border: 1px solid #e7c101; color: #bed2c0; color: #549237; }
+  .m4 { border-radius: 5px; border: 1px solid #6254f1; padding: 27px 5px; border-radius: 2px; text-align: center; background-color: #74e918; }
+  .m5 { line-height: 127%; line-height: 131%; font-weight: normal; background-color: #59fefb; }
+  .m6 { width: 32%; letter-spacing: 0.8px; border-radius: 12px; padding: 11px 23px; }
+  .m7 { border-radius: 6px; background-color: #1d2f03; font-size: 13px; text-align: left; }
+  .m8 { font-family: Georgia, 'Times New Roman', serif; border-radius: 2px; padding: 22px 20px; }
+  .m9 { font-size: 21px; max-width: 321px; background-color: #772cce; letter-spacing: 0.2px; color: #698a05; }
+  .m10 { color: #f86603; letter-spacing: 0.1px; letter-spacing: 0.8px; }
+  .m11 { border: 1px solid #bdcf47; font-size: 13px; line-height: 121%; font-size: 19px; text-decoration: underline; }
+  .m12 { text-decoration: underline; line-height: 129%; color: #3535b3; letter-spacing: 0.2px; font-family: 'Segoe UI', Roboto, sans-serif; margin: 17px 23px; }
+  .m13 { font-weight: 600; letter-spacing: 0.1px; background-color: #81a307; letter-spacing: 0.2px; width: 23%; border-radius: 8px; }
+  .m14 { padding: 11px 4px; margin: 15px 23px; font-family: 'Segoe UI', Roboto, sans-serif; border: 1px solid #e28a1b; margin: 24px 16px; line-height: 171%; }
+  .m15 { color: #be7b69; line-height: 120%; color: #7631c5; width: 36%; padding: 14px 14px; }
+  .m16 { border: 1px solid #fa8f6d; font-size: 20px; width: 38%; width: 78%; font-family: 'Segoe UI', Roboto, sans-serif; text-align: center; }
+  .m17 { max-width: 647px; width: 90%; padding: 21px 14px; line-height: 159%; background-color: #4cf905; }
+  .m18 { background-color: #b7b43d; border-radius: 10px; border-radius: 10px; text-decoration: underline; text-align: center; }
+  .m19 { border: 1px solid #97aa35; line-height: 148%; max-width: 297px; color: #e8be5b; color: #a6bc5a; text-align: right; }
+  .m20 { margin: 10px 0px; border: 1px solid #070439; font-weight: normal; max-width: 599px; border: 1px solid #2deccc; }
+  .m21 { border: 1px solid #f34e91; max-width: 508px; max-width: 655px; font-size: 12px; font-size: 30px; }
+  .m22 { line-height: 132%; border-radius: 1px; font-family: Georgia, 'Times New Roman', serif; font-size: 33px; }
+  .m23 { margin: 9px 17px; text-align: right; color: #94e7dd; border-radius: 5px; color: #fceaeb; border-radius: 13px; }
+  .m24 { border: 1px solid #17abcf; width: 46%; width: 77%; background-color: #a06061; background-color: #3166a7; margin: 27px 11px; }
+  .m25 { max-width: 577px; margin: 22px 19px; color: #7bc2e0; }
+  .m26 { color: #1047e3; border-radius: 4px; font-family: 'Segoe UI', Roboto, sans-serif; font-weight: 300; }
+  .m27 { text-align: left; padding: 1px 4px; font-weight: normal; background-color: #452db4; text-align: center; letter-spacing: 0.5px; }
+  .m28 { letter-spacing: 0.6px; font-family: Helvetica, Arial, sans-serif; width: 34%; padding: 0px 23px; }
+  .m29 { padding: 24px 20px; text-align: center; font-family: Helvetica, Arial, sans-serif; letter-spacing: 0.5px; }
+  .m30 { max-width: 552px; line-height: 121%; max-width: 285px; letter-spacing: 0.3px; }
+  .m31 { border: 1px solid #15278a; max-width: 537px; width: 96%; max-width: 671px; font-size: 12px; }
+  .m32 { max-width: 462px; text-align: right; border: 1px solid #207655; font-size: 26px; font-size: 32px; }
+  .m33 { text-align: center; color: #e7efb6; line-height: 155%; color: #a43b39; }
+  .m34 { padding: 27px 17px; text-decoration: none; border: 1px solid #3f2dc3; margin: 17px 18px; font-family: Helvetica, Arial, sans-serif; }
+  .m35 { border-radius: 10px; font-size: 15px; font-family: 'Segoe UI', Roboto, sans-serif; background-color: #e30404; color: #36c551; width: 52%; }
+  .m36 { color: #6fd108; font-weight: 300; margin: 23px 10px; background-color: #62c349; max-width: 664px; }
+  .m37 { background-color: #fe8952; letter-spacing: 0.2px; font-size: 18px; max-width: 404px; width: 58%; }
+  .m38 { border-radius: 13px; color: #d21cf7; line-height: 167%; font-size: 28px; }
+  .m39 { text-align: right; text-align: right; padding: 22px 25px; width: 69%; font-family: 'Segoe UI', Roboto, sans-serif; line-height: 121%; }
+  .m40 { text-decoration: none; max-width: 583px; font-size: 31px; font-size: 13px; text-decoration: underline; }
+  .m41 { letter-spacing: 0.7px; border: 1px solid #ed2552; color: #be46b4; }
+  .m42 { border-radius: 1px; margin: 20px 11px; font-size: 29px; padding: 15px 29px; }
+  .m43 { color: #00a881; color: #ab341e; padding: 7px 15px; width: 96%; text-decoration: underline; }
+  .m44 { background-color: #cac488; border: 1px solid #ccf8b7; background-color: #0be277; text-decoration: underline; font-family: Georgia, 'Times New Roman', serif; line-height: 140%; }
+</style>
+<style type="text/css">
+  @media screen and (max-width: 600px) {
+    .r0 { width: 44%; letter-spacing: 0.4px; }
+    .r1 { border-radius: 4px; line-height: 142%; border: 1px solid #c2b0ce; border: 1px solid #387f9f; }
+    .r2 { text-align: center; width: 82%; padding: 26px 11px; }
+    .r3 { border-radius: 10px; padding: 11px 11px; max-width: 360px; }
+    .r4 { max-width: 611px; border-radius: 8px; }
+    .r5 { text-decoration: none; font-size: 11px; line-height: 151%; }
+    .r6 { margin: 0px 23px; margin: 6px 14px; background-color: #2ee214; }
+    .r7 { letter-spacing: 0.7px; background-color: #ca1ad4; font-size: 21px; line-height: 128%; }
+    .r8 { max-width: 581px; text-decoration: none; color: #ee6c23; }
+    .r9 { width: 81%; max-width: 297px; text-align: right; line-height: 143%; }
+    .r10 { max-width: 608px; border: 1px solid #3f7522; color: #a47e4a; }
+    .r11 { margin: 18px 16px; text-decoration: none; }
+    .r12 { max-width: 478px; padding: 25px 17px; width: 81%; font-weight: 300; }
+    .r13 { margin: 2px 14px; border-radius: 12px; line-height: 132%; font-size: 26px; }
+    .r14 { line-height: 153%; width: 53%; }
+    .r15 { padding: 25px 21px; text-decoration: underline; text-align: right; text-align: right; }
+    .r16 { margin: 23px 13px; color: #8b3b18; }
+    .r17 { text-decoration: underline; margin: 22px 3px; width: 83%; }
+    .r18 { letter-spacing: 0.3px; max-width: 394px; }
+    .r19 { width: 23%; border-radius: 12px; letter-spacing: 0.2px; }
+    .r20 { line-height: 168%; background-color: #4ee15b; font-size: 23px; border: 1px solid #a8b56a; }
+    .r21 { font-family: Georgia, 'Times New Roman', serif; border-radius: 2px; font-family: Helvetica, Arial, sans-serif; text-decoration: underline; }
+    .r22 { border-radius: 9px; font-size: 19px; font-size: 15px; letter-spacing: 0.6px; }
+    .r23 { font-size: 14px; color: #de0a73; }
+    .r24 { font-size: 30px; text-align: left; line-height: 166%; }
+  }
+  @media (prefers-color-scheme: dark) {
+    .d0 { color: #9d3e2d; background-color: #9b39a1; }
+    .d1 { color: #d6494c; background-color: #2364bd; }
+    .d2 { color: #5f7927; background-color: #7c4683; }
+    .d3 { color: #9862d1; background-color: #bb502a; }
+    .d4 { color: #234871; background-color: #012909; }
+    .d5 { color: #73cfec; background-color: #1589b0; }
+    .d6 { color: #33b2f4; background-color: #2cd605; }
+    .d7 { color: #1b9dbf; background-color: #805fa8; }
+    .d8 { color: #96ac8b; background-color: #c7a457; }
+    .d9 { color: #a79201; background-color: #3d4e1b; }
+    .d10 { color: #65a2b6; background-color: #6f01f3; }
+    .d11 { color: #668390; background-color: #a98b0a; }
+    .d12 { color: #83429f; background-color: #a8d509; }
+    .d13 { color: #868f70; background-color: #0c69aa; }
+    .d14 { color: #c9b5fd; background-color: #4ea5a1; }
+  }
+</style>
+</head>
+<body>
+<center>
+<table role="presentation" width="100%"><tbody><tr><td>
+<table role="presentation" class="m0" width="100%" style="border-radius: 13px; margin: 18px 14px"><tbody>
+<tr><td class="r0">
+<h2 style="margin: 0px 16px; max-width: 507px; color: #b664cf; max-width: 637px">Section 1: what shipped this month</h2>
+<p style="color: #2cbe42; width: 77%">Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d0">
+<img src="https://cdn.example.com/img/thumb-0-0.png" alt="" width="180">
+<h3>Item 1</h3>
+<p style="color: #435e93; font-size: 31px; width: 69%">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/0/0">Read more</a>
+</td>
+<td class="d1" style="color: #e7fddd; color: #fbd222; background-color: #a8cf4f; border-radius: 7px">
+<img src="https://cdn.example.com/img/thumb-0-1.png" alt="" style="background-color: #ed4e9f; width: 92%" width="180">
+<h3 style="font-family: 'Segoe UI', Roboto, sans-serif; width: 25%; color: #b26145; margin: 6px 19px">Item 2</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/0/1">Read more</a>
+</td>
+<td class="d2">
+<img src="https://cdn.example.com/img/thumb-0-2.png" alt="" width="180">
+<h3>Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/0/2">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation" style="padding: 26px 9px; line-height: 114%"><tbody><tr><td style="font-weight: 300; text-decoration: none">
+<a href="https://www.example.com/cta/0">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m1" width="100%" style="text-decoration: none; text-align: center; max-width: 672px; color: #396ea3; border: 1px solid #a6a0bd"><tbody>
+<tr><td class="r1" style="padding: 11px 10px; letter-spacing: 0.6px; max-width: 534px; margin: 15px 4px; color: #7fb2ee; background-image: url(https://cdn.example.com/img/hero-510.png)">
+<h2>Section 2: what shipped this month</h2>
+<p style="background-color: #1b41b4; background-color: #c1a8bb">Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d1" style="margin: 23px 2px; margin: 23px 9px; text-align: left">
+<img src="https://cdn.example.com/img/thumb-1-0.png" alt="" style="font-family: Georgia, 'Times New Roman', serif; line-height: 164%; font-size: 23px" width="180">
+<h3>Item 1</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/1/0" style="text-decoration: underline; text-align: left">Read more</a>
+</td>
+<td class="d2" style="line-height: 175%; border: 1px solid #1a716c; font-family: Helvetica, Arial, sans-serif; border: 1px solid #d64c6b">
+<img src="https://cdn.example.com/img/thumb-1-1.png" alt="" style="padding: 1px 22px; font-size: 24px; border-radius: 1px; max-width: 420px" width="180">
+<h3>Item 2</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/1/1" style="letter-spacing: 0.4px; padding: 5px 7px; line-height: 160%; border: 1px solid #9433c5; border: 1px solid #565e34">Read more</a>
+</td>
+<td class="d3" style="font-size: 12px; padding: 26px 13px">
+<img src="https://cdn.example.com/img/thumb-1-2.png" alt="" width="180">
+<h3>Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/1/2" style="line-height: 137%; font-weight: bold; font-weight: 300">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation"><tbody><tr><td style="letter-spacing: 0.2px; text-decoration: underline; max-width: 568px; border: 1px solid #cd601d; border: 1px solid #bdcf0a">
+<a href="https://www.example.com/cta/1" style="text-align: right; margin: 7px 9px; width: 23%; font-family: Verdana, Geneva, sans-serif; font-family: Verdana, Geneva, sans-serif">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m2" width="100%" style="text-align: left; margin: 24px 1px; text-decoration: underline; color: #e45004; font-size: 24px"><tbody>
+<tr><td class="r2">
+<h2 style="line-height: 172%; font-size: 13px; font-family: Verdana, Geneva, sans-serif; letter-spacing: 0.3px; text-align: center">Section 3: what shipped this month</h2>
+<p style="background-color: #fbffb2; border: 1px solid #f3a523; letter-spacing: 0.5px">Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d2" style="border: 1px solid #f6bda3; color: #6106c4; padding: 8px 28px; text-decoration: underline; background-image: url(https://cdn.example.com/img/hero-7.png)">
+<img src="https://cdn.example.com/img/thumb-2-0.png" alt="" style="border: 1px solid #9f3a1c; border-radius: 10px; font-weight: 300; width: 93%" width="180">
+<h3>Item 1</h3>
+<p style="max-width: 318px; color: #1aef96">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/2/0" style="border-radius: 9px; border: 1px solid #4c9580; background-color: #d0319b; letter-spacing: 0.6px">Read more</a>
+</td>
+<td class="d3" style="margin: 12px 20px; font-family: Helvetica, Arial, sans-serif; padding: 25px 10px; line-height: 116%">
+<img src="https://cdn.example.com/img/thumb-2-1.png" alt="" width="180">
+<h3 style="width: 36%; max-width: 369px; border-radius: 2px; font-size: 28px">Item 2</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/2/1">Read more</a>
+</td>
+<td class="d4" style="color: #39e85f; padding: 22px 31px; text-decoration: underline">
+<img src="https://cdn.example.com/img/thumb-2-2.png" alt="" width="180">
+<h3>Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/2/2" style="color: #3267ff; text-decoration: underline; margin: 16px 1px; width: 34%; font-weight: normal">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation" style="text-decoration: underline; text-align: left; max-width: 623px; line-height: 167%"><tbody><tr><td style="letter-spacing: 0.3px; font-size: 15px; line-height: 164%; margin: 3px 11px">
+<a href="https://www.example.com/cta/2" style="text-decoration: none; border-radius: 10px; text-align: left; font-weight: normal">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m3" width="100%" style="padding: 1px 24px; letter-spacing: 0.3px; text-decoration: underline; border-radius: 3px"><tbody>
+<tr><td class="r3">
+<h2 style="text-decoration: none; letter-spacing: 0.8px; line-height: 155%; font-weight: 600">Section 4: what shipped this month</h2>
+<p style="letter-spacing: 0.4px; background-color: #db9bb9; font-family: Helvetica, Arial, sans-serif">Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d3" style="border-radius: 10px; border-radius: 2px">
+<img src="https://cdn.example.com/img/thumb-3-0.png" alt="" width="180">
+<h3>Item 1</h3>
+<p style="font-weight: normal; font-family: 'Segoe UI', Roboto, sans-serif; margin: 7px 18px; line-height: 125%">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/3/0">Read more</a>
+</td>
+<td class="d4">
+<img src="https://cdn.example.com/img/thumb-3-1.png" alt="" width="180">
+<h3 style="letter-spacing: 0.6px; border: 1px solid #7d6d61; letter-spacing: 0.1px; text-align: right; color: #291015">Item 2</h3>
+<p style="border-radius: 1px; line-height: 148%">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/3/1" style="background-color: #167318; text-decoration: none; text-decoration: none">Read more</a>
+</td>
+<td class="d5" style="font-size: 16px; letter-spacing: 0.2px">
+<img src="https://cdn.example.com/img/thumb-3-2.png" alt="" style="letter-spacing: 0.8px; text-align: center; padding: 20px 6px" width="180">
+<h3 style="border-radius: 3px; margin: 26px 10px; width: 99%; font-weight: 600; background-color: #9149a3">Item 3</h3>
+<p style="max-width: 559px; padding: 4px 25px; margin: 8px 20px; margin: 1px 6px; border: 1px solid #eca532">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/3/2" style="border-radius: 11px; border: 1px solid #54d3aa; letter-spacing: 0.8px; max-width: 573px">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation" style="font-weight: bold; color: #2d1249; max-width: 558px"><tbody><tr><td>
+<a href="https://www.example.com/cta/3" style="font-family: Verdana, Geneva, sans-serif; padding: 4px 31px; font-size: 32px; font-size: 28px; line-height: 172%; background-image: url(https://cdn.example.com/img/hero-519.png)">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m4" width="100%"><tbody>
+<tr><td class="r4" style="border-radius: 9px; color: #5bca3f; text-decoration: underline; text-decoration: underline; width: 22%">
+<h2 style="background-color: #5c3b25; font-weight: 600; text-decoration: underline; letter-spacing: 0.5px">Section 5: what shipped this month</h2>
+<p>Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d4" style="letter-spacing: 0.7px; max-width: 539px; background-color: #34b273; text-decoration: underline; padding: 20px 5px">
+<img src="https://cdn.example.com/img/thumb-4-0.png" alt="" width="180">
+<h3>Item 1</h3>
+<p style="background-color: #80c64b; text-decoration: none; letter-spacing: 0.4px; padding: 22px 6px; max-width: 493px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/4/0">Read more</a>
+</td>
+<td class="d5" style="line-height: 182%; text-decoration: none; margin: 6px 9px">
+<img src="https://cdn.example.com/img/thumb-4-1.png" alt="" style="font-weight: normal; font-family: Georgia, 'Times New Roman', serif; padding: 10px 23px; text-decoration: none; font-size: 13px" width="180">
+<h3 style="border: 1px solid #16d774; background-color: #72800e; font-weight: 600; border-radius: 9px; padding: 15px 30px">Item 2</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/4/1" style="text-align: right; line-height: 141%; line-height: 130%">Read more</a>
+</td>
+<td class="d6" style="border-radius: 0px; width: 59%; font-weight: 300; max-width: 381px; color: #3d3bdf; background-image: url(https://cdn.example.com/img/hero-126.png)">
+<img src="https://cdn.example.com/img/thumb-4-2.png" alt="" style="max-width: 585px; font-weight: 600; font-family: Helvetica, Arial, sans-serif" width="180">
+<h3 style="background-color: #283c96; line-height: 110%; color: #0fe1ae; color: #b9a01c">Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/4/2">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation"><tbody><tr><td>
+<a href="https://www.example.com/cta/4" style="border-radius: 3px; border-radius: 0px; font-size: 11px">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m5" width="100%"><tbody>
+<tr><td class="r5">
+<h2 style="line-height: 137%; background-color: #b71652">Section 6: what shipped this month</h2>
+<p>Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d5">
+<img src="https://cdn.example.com/img/thumb-5-0.png" alt="" style="width: 56%; padding: 19px 21px; text-align: left" width="180">
+<h3>Item 1</h3>
+<p style="text-align: left; margin: 5px 22px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/5/0" style="font-family: Helvetica, Arial, sans-serif; font-family: Helvetica, Arial, sans-serif; font-weight: 600; line-height: 176%; margin: 23px 18px">Read more</a>
+</td>
+<td class="d6" style="margin: 20px 13px; text-decoration: underline; font-family: Verdana, Geneva, sans-serif">
+<img src="https://cdn.example.com/img/thumb-5-1.png" alt="" style="text-decoration: underline; background-color: #634b70; text-align: right; line-height: 123%" width="180">
+<h3>Item 2</h3>
+<p style="text-align: right; margin: 2px 21px; border-radius: 1px; letter-spacing: 0.5px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/5/1">Read more</a>
+</td>
+<td class="d7" style="border-radius: 1px; border-radius: 8px; margin: 10px 13px; text-align: right">
+<img src="https://cdn.example.com/img/thumb-5-2.png" alt="" style="background-color: #5096d1; color: #ae9ca2; border-radius: 11px" width="180">
+<h3>Item 3</h3>
+<p style="border: 1px solid #84eb5a; width: 62%; letter-spacing: 0.8px; max-width: 607px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/5/2" style="letter-spacing: 0.6px; padding: 15px 11px; width: 49%; line-height: 177%; text-decoration: underline">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation" style="width: 74%; font-weight: 600; max-width: 451px; margin: 24px 4px"><tbody><tr><td>
+<a href="https://www.example.com/cta/5">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m6" width="100%" style="line-height: 116%; font-size: 19px; text-decoration: underline; font-family: Helvetica, Arial, sans-serif"><tbody>
+<tr><td class="r6">
+<h2 style="text-decoration: none; text-align: center; font-weight: bold; text-decoration: underline; text-decoration: none">Section 7: what shipped this month</h2>
+<p>Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%" style="text-decoration: none; color: #0dc0cc; font-weight: 600"><tbody><tr>
+<td class="d6">
+<img src="https://cdn.example.com/img/thumb-6-0.png" alt="" width="180">
+<h3>Item 1</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/6/0" style="background-color: #f7d4b6; margin: 19px 8px">Read more</a>
+</td>
+<td class="d7" style="max-width: 600px; width: 52%">
+<img src="https://cdn.example.com/img/thumb-6-1.png" alt="" style="font-weight: 300; padding: 17px 7px; color: #e38823" width="180">
+<h3>Item 2</h3>
+<p style="font-size: 13px; border: 1px solid #ed316d; width: 43%">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/6/1" style="line-height: 157%; color: #59c8fd; letter-spacing: 0.2px; width: 93%">Read more</a>
+</td>
+<td class="d8">
+<img src="https://cdn.example.com/img/thumb-6-2.png" alt="" width="180">
+<h3>Item 3</h3>
+<p style="font-weight: 300; line-height: 114%; font-weight: normal; font-size: 18px; margin: 5px 11px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/6/2">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation"><tbody><tr><td>
+<a href="https://www.example.com/cta/6" style="font-size: 32px; text-align: left; border-radius: 4px">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m7" width="100%" style="border-radius: 2px; text-decoration: none; background-color: #396425"><tbody>
+<tr><td class="r7">
+<h2 style="line-height: 156%; border-radius: 12px; line-height: 128%">Section 8: what shipped this month</h2>
+<p style="background-color: #c7a55b; font-family: Helvetica, Arial, sans-serif">Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d7" style="border: 1px solid #b78720; font-size: 12px; font-size: 19px; background-color: #f41195">
+<img src="https://cdn.example.com/img/thumb-7-0.png" alt="" width="180">
+<h3>Item 1</h3>
+<p style="width: 96%; font-size: 18px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/7/0" style="font-size: 28px; color: #0fa27d">Read more</a>
+</td>
+<td class="d8" style="width: 35%; font-size: 21px">
+<img src="https://cdn.example.com/img/thumb-7-1.png" alt="" width="180">
+<h3>Item 2</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/7/1">Read more</a>
+</td>
+<td class="d9">
+<img src="https://cdn.example.com/img/thumb-7-2.png" alt="" width="180">
+<h3 style="line-height: 111%; font-weight: 600; font-size: 11px; line-height: 122%">Item 3</h3>
+<p style="background-color: #b47989; font-size: 27px; max-width: 377px; border: 1px solid #82ffd0">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/7/2">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation"><tbody><tr><td>
+<a href="https://www.example.com/cta/7">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m8" width="100%" style="text-align: right; line-height: 146%; background-color: #82e225"><tbody>
+<tr><td class="r8" style="font-weight: normal; margin: 13px 3px; font-size: 11px; line-height: 184%; max-width: 554px">
+<h2>Section 9: what shipped this month</h2>
+<p>Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d8">
+<img src="https://cdn.example.com/img/thumb-8-0.png" alt="" style="line-height: 178%; max-width: 532px; font-weight: 300; font-family: Helvetica, Arial, sans-serif; padding: 24px 24px" width="180">
+<h3>Item 1</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/8/0">Read more</a>
+</td>
+<td class="d9" style="font-family: 'Segoe UI', Roboto, sans-serif; text-align: right; width: 52%; width: 62%; margin: 27px 12px">
+<img src="https://cdn.example.com/img/thumb-8-1.png" alt="" width="180">
+<h3>Item 2</h3>
+<p style="margin: 21px 19px; max-width: 344px; font-size: 22px; color: #143cd3">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/8/1" style="line-height: 147%; color: #0d5ca2; line-height: 160%; border-radius: 6px; text-align: center">Read more</a>
+</td>
+<td class="d10">
+<img src="https://cdn.example.com/img/thumb-8-2.png" alt="" style="color: #11c498; width: 88%; padding: 17px 15px; padding: 18px 9px" width="180">
+<h3>Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/8/2">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation" style="color: #fb30bf; padding: 21px 22px; width: 56%; margin: 25px 19px; font-family: Helvetica, Arial, sans-serif"><tbody><tr><td>
+<a href="https://www.example.com/cta/8">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m9" width="100%"><tbody>
+<tr><td class="r9" style="text-align: left; font-family: Helvetica, Arial, sans-serif; text-align: center">
+<h2>Section 10: what shipped this month</h2>
+<p>Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d9">
+<img src="https://cdn.example.com/img/thumb-9-0.png" alt="" style="line-height: 147%; color: #07fa85; color: #7d18cf; font-size: 29px" width="180">
+<h3>Item 1</h3>
+<p style="margin: 25px 0px; text-decoration: underline; text-align: right; text-decoration: none; color: #5cc5eb">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/9/0">Read more</a>
+</td>
+<td class="d10" style="border: 1px solid #53953e; font-family: 'Segoe UI', Roboto, sans-serif; font-size: 14px; text-decoration: underline">
+<img src="https://cdn.example.com/img/thumb-9-1.png" alt="" width="180">
+<h3>Item 2</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/9/1">Read more</a>
+</td>
+<td class="d11" style="margin: 20px 23px; text-decoration: underline; background-image: url(https://cdn.example.com/img/hero-688.png)">
+<img src="https://cdn.example.com/img/thumb-9-2.png" alt="" width="180">
+<h3>Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/9/2" style="max-width: 370px; padding: 23px 27px; line-height: 137%; background-color: #298391">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation"><tbody><tr><td>
+<a href="https://www.example.com/cta/9" style="border-radius: 3px; text-align: center; background-image: url(https://cdn.example.com/img/hero-653.png)">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m10" width="100%"><tbody>
+<tr><td class="r10">
+<h2>Section 11: what shipped this month</h2>
+<p style="font-family: Georgia, 'Times New Roman', serif; background-color: #9bb254; font-size: 27px; background-color: #579035">Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d10">
+<img src="https://cdn.example.com/img/thumb-10-0.png" alt="" style="text-decoration: underline; margin: 22px 13px; border-radius: 1px; padding: 3px 19px" width="180">
+<h3>Item 1</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/10/0">Read more</a>
+</td>
+<td class="d11" style="border-radius: 4px; text-align: left">
+<img src="https://cdn.example.com/img/thumb-10-1.png" alt="" style="background-color: #2c4388; font-weight: 600; font-family: 'Segoe UI', Roboto, sans-serif; padding: 5px 17px" width="180">
+<h3>Item 2</h3>
+<p style="text-align: center; margin: 30px 1px; border: 1px solid #9dd68f; border: 1px solid #6f4893">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/10/1">Read more</a>
+</td>
+<td class="d12">
+<img src="https://cdn.example.com/img/thumb-10-2.png" alt="" width="180">
+<h3>Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/10/2">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation"><tbody><tr><td style="text-align: center; font-family: Helvetica, Arial, sans-serif; font-family: Verdana, Geneva, sans-serif">
+<a href="https://www.example.com/cta/10">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m11" width="100%"><tbody>
+<tr><td class="r11">
+<h2>Section 12: what shipped this month</h2>
+<p>Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%" style="padding: 4px 22px; width: 83%; padding: 11px 11px"><tbody><tr>
+<td class="d11" style="padding: 17px 15px; margin: 31px 10px; text-decoration: underline">
+<img src="https://cdn.example.com/img/thumb-11-0.png" alt="" width="180">
+<h3 style="padding: 8px 10px; color: #ff51ef; color: #505c27; text-decoration: underline; text-align: right">Item 1</h3>
+<p style="max-width: 383px; letter-spacing: 0.6px; font-weight: normal">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/11/0" style="text-decoration: underline; border: 1px solid #6cdb2e; letter-spacing: 0.7px">Read more</a>
+</td>
+<td class="d12" style="line-height: 174%; font-size: 21px; font-family: Verdana, Geneva, sans-serif; font-family: 'Segoe UI', Roboto, sans-serif">
+<img src="https://cdn.example.com/img/thumb-11-1.png" alt="" style="text-decoration: none; width: 85%" width="180">
+<h3>Item 2</h3>
+<p style="font-family: Helvetica, Arial, sans-serif; margin: 1px 9px; text-decoration: underline; font-weight: bold">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/11/1" style="border: 1px solid #12ed00; background-color: #4bfb5c; padding: 18px 23px">Read more</a>
+</td>
+<td class="d13">
+<img src="https://cdn.example.com/img/thumb-11-2.png" alt="" width="180">
+<h3>Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/11/2">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation"><tbody><tr><td style="letter-spacing: 0.3px; text-decoration: none; font-size: 31px">
+<a href="https://www.example.com/cta/11" style="border-radius: 8px; font-size: 20px; font-size: 26px">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m12" width="100%"><tbody>
+<tr><td class="r12" style="border-radius: 3px; border: 1px solid #a59ce7; text-decoration: underline; font-size: 15px; padding: 19px 21px">
+<h2>Section 13: what shipped this month</h2>
+<p>Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%" style="text-align: right; font-size: 16px"><tbody><tr>
+<td class="d12">
+<img src="https://cdn.example.com/img/thumb-12-0.png" alt="" width="180">
+<h3>Item 1</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/12/0">Read more</a>
+</td>
+<td class="d13">
+<img src="https://cdn.example.com/img/thumb-12-1.png" alt="" width="180">
+<h3 style="line-height: 130%; padding: 24px 21px; font-family: Helvetica, Arial, sans-serif; font-size: 25px">Item 2</h3>
+<p style="text-decoration: underline; margin: 17px 20px; max-width: 318px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/12/1" style="margin: 5px 0px; font-family: Verdana, Geneva, sans-serif; color: #507cbc">Read more</a>
+</td>
+<td class="d14" style="line-height: 133%; background-color: #d9974b; width: 25%; background-color: #4ef399; background-color: #e50750">
+<img src="https://cdn.example.com/img/thumb-12-2.png" alt="" width="180">
+<h3>Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/12/2">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation"><tbody><tr><td style="background-color: #4c1ca5; font-size: 32px; max-width: 384px; letter-spacing: 0.4px; margin: 7px 22px">
+<a href="https://www.example.com/cta/12" style="font-weight: bold; background-color: #bc7dfa">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m13" width="100%" style="text-decoration: none; max-width: 335px"><tbody>
+<tr><td class="r13">
+<h2>Section 14: what shipped this month</h2>
+<p style="font-family: Georgia, 'Times New Roman', serif; text-align: left; border-radius: 1px">Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d13" style="line-height: 185%; font-size: 11px; color: #61c7ed; padding: 14px 17px">
+<img src="https://cdn.example.com/img/thumb-13-0.png" alt="" width="180">
+<h3 style="border-radius: 1px; border-radius: 6px; color: #8d6e5b; border: 1px solid #5fe444; text-align: center">Item 1</h3>
+<p style="border-radius: 3px; max-width: 304px; line-height: 156%; max-width: 354px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/13/0" style="line-height: 187%; letter-spacing: 0.7px; line-height: 177%; font-weight: bold">Read more</a>
+</td>
+<td class="d14" style="letter-spacing: 0.4px; border-radius: 5px; text-align: center">
+<img src="https://cdn.example.com/img/thumb-13-1.png" alt="" style="font-family: Georgia, 'Times New Roman', serif; max-width: 569px; padding: 10px 7px" width="180">
+<h3>Item 2</h3>
+<p style="max-width: 314px; color: #e73956; font-size: 32px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/13/1">Read more</a>
+</td>
+<td class="d0">
+<img src="https://cdn.example.com/img/thumb-13-2.png" alt="" style="text-decoration: underline; color: #12d855; text-decoration: underline" width="180">
+<h3 style="line-height: 156%; border-radius: 9px; background-color: #b386dd">Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/13/2" style="color: #a07093; text-align: left; font-size: 16px; text-decoration: underline">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation" style="text-align: right; text-align: center; border: 1px solid #898398; border: 1px solid #8be698"><tbody><tr><td>
+<a href="https://www.example.com/cta/13" style="border: 1px solid #78118e; letter-spacing: 0.6px; max-width: 625px">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m14" width="100%"><tbody>
+<tr><td class="r14">
+<h2>Section 15: what shipped this month</h2>
+<p style="padding: 17px 30px; letter-spacing: 0.3px">Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d14" style="font-family: Georgia, 'Times New Roman', serif; line-height: 181%; width: 72%">
+<img src="https://cdn.example.com/img/thumb-14-0.png" alt="" style="width: 32%; margin: 20px 3px" width="180">
+<h3>Item 1</h3>
+<p style="padding: 15px 14px; text-align: right; font-weight: normal; padding: 20px 9px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/14/0">Read more</a>
+</td>
+<td class="d0">
+<img src="https://cdn.example.com/img/thumb-14-1.png" alt="" width="180">
+<h3 style="color: #2795a9; line-height: 125%; padding: 0px 5px; letter-spacing: 0.8px">Item 2</h3>
+<p style="margin: 11px 4px; background-color: #1e1933; line-height: 172%; padding: 0px 11px; margin: 23px 12px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/14/1">Read more</a>
+</td>
+<td class="d1" style="letter-spacing: 0.4px; margin: 5px 11px; line-height: 144%; border-radius: 6px; background-image: url(https://cdn.example.com/img/hero-269.png)">
+<img src="https://cdn.example.com/img/thumb-14-2.png" alt="" width="180">
+<h3>Item 3</h3>
+<p style="text-align: left; margin: 19px 18px; font-size: 18px; font-size: 29px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/14/2" style="background-color: #71407c; line-height: 142%; width: 42%">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation" style="line-height: 147%; border-radius: 3px; padding: 24px 30px"><tbody><tr><td style="font-size: 31px; text-decoration: underline; border: 1px solid #a4efdd; max-width: 538px; text-align: left">
+<a href="https://www.example.com/cta/14">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m15" width="100%"><tbody>
+<tr><td class="r15" style="font-size: 14px; border: 1px solid #fd95fb">
+<h2 style="text-decoration: underline; font-size: 13px; line-height: 161%">Section 16: what shipped this month</h2>
+<p>Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d0">
+<img src="https://cdn.example.com/img/thumb-15-0.png" alt="" width="180">
+<h3>Item 1</h3>
+<p style="letter-spacing: 0.2px; text-align: center">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/15/0">Read more</a>
+</td>
+<td class="d1">
+<img src="https://cdn.example.com/img/thumb-15-1.png" alt="" width="180">
+<h3 style="font-size: 33px; text-align: left; width: 31%; line-height: 116%; text-decoration: underline">Item 2</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/15/1">Read more</a>
+</td>
+<td class="d2">
+<img src="https://cdn.example.com/img/thumb-15-2.png" alt="" style="width: 57%; letter-spacing: 0.7px; border: 1px solid #8ebd56; font-family: Georgia, 'Times New Roman', serif" width="180">
+<h3 style="font-family: Verdana, Geneva, sans-serif; width: 30%; line-height: 110%">Item 3</h3>
+<p style="text-decoration: none; font-size: 24px; margin: 1px 16px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/15/2">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation"><tbody><tr><td>
+<a href="https://www.example.com/cta/15" style="font-family: Verdana, Geneva, sans-serif; border: 1px solid #c32d0a; margin: 10px 17px; text-decoration: none">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m16" width="100%"><tbody>
+<tr><td class="r16" style="border: 1px solid #3e9d0b; line-height: 148%; text-decoration: underline">
+<h2>Section 17: what shipped this month</h2>
+<p style="text-decoration: underline; margin: 13px 20px; font-size: 15px; letter-spacing: 0.4px; font-weight: 600">Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%" style="color: #e53a94; font-size: 30px; padding: 9px 31px"><tbody><tr>
+<td class="d1">
+<img src="https://cdn.example.com/img/thumb-16-0.png" alt="" width="180">
+<h3>Item 1</h3>
+<p style="border: 1px solid #88a66b; font-size: 27px; line-height: 131%">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/16/0">Read more</a>
+</td>
+<td class="d2">
+<img src="https://cdn.example.com/img/thumb-16-1.png" alt="" style="font-size: 11px; letter-spacing: 0.7px; letter-spacing: 0.2px; text-align: left; max-width: 517px" width="180">
+<h3>Item 2</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/16/1">Read more</a>
+</td>
+<td class="d3">
+<img src="https://cdn.example.com/img/thumb-16-2.png" alt="" width="180">
+<h3>Item 3</h3>
+<p style="font-family: 'Segoe UI', Roboto, sans-serif; color: #e3cff2">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/16/2">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation" style="max-width: 316px; color: #450a53"><tbody><tr><td style="margin: 12px 10px; border-radius: 1px; text-decoration: none; background-color: #d0bac9; margin: 12px 4px">
+<a href="https://www.example.com/cta/16">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m17" width="100%"><tbody>
+<tr><td class="r17">
+<h2>Section 18: what shipped this month</h2>
+<p>Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%" style="font-weight: 600; width: 63%; color: #44a411; border: 1px solid #caae32; padding: 1px 13px"><tbody><tr>
+<td class="d2" style="border-radius: 10px; background-color: #838b66">
+<img src="https://cdn.example.com/img/thumb-17-0.png" alt="" width="180">
+<h3>Item 1</h3>
+<p style="max-width: 410px; border-radius: 9px; margin: 18px 2px; text-decoration: underline; font-family: Verdana, Geneva, sans-serif">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/17/0">Read more</a>
+</td>
+<td class="d3" style="font-weight: 300; width: 85%; line-height: 160%">
+<img src="https://cdn.example.com/img/thumb-17-1.png" alt="" width="180">
+<h3>Item 2</h3>
+<p style="letter-spacing: 0.7px; text-align: left">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/17/1">Read more</a>
+</td>
+<td class="d4" style="border-radius: 12px; text-decoration: none; font-weight: 600">
+<img src="https://cdn.example.com/img/thumb-17-2.png" alt="" style="font-family: 'Segoe UI', Roboto, sans-serif; text-decoration: none; max-width: 579px; padding: 20px 21px" width="180">
+<h3 style="border: 1px solid #60f737; width: 86%; width: 57%; font-weight: normal; border: 1px solid #99bc2a">Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/17/2">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation" style="border: 1px solid #2a4290; background-color: #610d3c; line-height: 118%; max-width: 654px"><tbody><tr><td>
+<a href="https://www.example.com/cta/17">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m18" width="100%" style="padding: 13px 7px; text-align: right; background-color: #8ca75a; font-size: 24px; background-color: #3f9b09"><tbody>
+<tr><td class="r18">
+<h2 style="margin: 13px 1px; background-color: #a1e94d; width: 53%; border: 1px solid #9525fa; border-radius: 4px">Section 19: what shipped this month</h2>
+<p>Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%" style="border-radius: 5px; letter-spacing: 0.5px; border-radius: 2px"><tbody><tr>
+<td class="d3" style="color: #d37a83; background-color: #4c595a">
+<img src="https://cdn.example.com/img/thumb-18-0.png" alt="" style="letter-spacing: 0.3px; width: 95%; padding: 14px 17px" width="180">
+<h3>Item 1</h3>
+<p style="line-height: 182%; font-weight: 600; font-weight: bold; text-decoration: none">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/18/0">Read more</a>
+</td>
+<td class="d4">
+<img src="https://cdn.example.com/img/thumb-18-1.png" alt="" style="width: 90%; font-size: 25px; margin: 5px 6px" width="180">
+<h3>Item 2</h3>
+<p style="font-family: 'Segoe UI', Roboto, sans-serif; width: 62%; font-weight: 600">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/18/1">Read more</a>
+</td>
+<td class="d5">
+<img src="https://cdn.example.com/img/thumb-18-2.png" alt="" style="max-width: 641px; font-weight: normal; text-align: center; max-width: 442px" width="180">
+<h3>Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/18/2">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation" style="max-width: 550px; border: 1px solid #dba71d; width: 60%"><tbody><tr><td style="padding: 8px 24px; max-width: 407px; letter-spacing: 0.2px; font-weight: bold">
+<a href="https://www.example.com/cta/18">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m19" width="100%" style="border-radius: 9px; line-height: 176%; line-height: 152%"><tbody>
+<tr><td class="r19">
+<h2>Section 20: what shipped this month</h2>
+<p>Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d4" style="font-size: 30px; letter-spacing: 0.6px">
+<img src="https://cdn.example.com/img/thumb-19-0.png" alt="" style="text-decoration: none; max-width: 671px" width="180">
+<h3>Item 1</h3>
+<p style="font-family: Georgia, 'Times New Roman', serif; text-decoration: none; width: 94%; letter-spacing: 0.6px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/19/0">Read more</a>
+</td>
+<td class="d5">
+<img src="https://cdn.example.com/img/thumb-19-1.png" alt="" style="text-decoration: underline; border: 1px solid #cb4089; border-radius: 11px" width="180">
+<h3>Item 2</h3>
+<p style="padding: 22px 27px; text-align: center; font-family: Georgia, 'Times New Roman', serif; width: 29%; line-height: 119%">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/19/1">Read more</a>
+</td>
+<td class="d6">
+<img src="https://cdn.example.com/img/thumb-19-2.png" alt="" style="max-width: 414px; padding: 2px 7px" width="180">
+<h3 style="padding: 17px 23px; font-family: 'Segoe UI', Roboto, sans-serif; line-height: 144%; border: 1px solid #260679; color: #e174fb">Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/19/2" style="line-height: 164%; margin: 18px 9px; font-size: 30px; background-color: #e67025; text-align: left">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation"><tbody><tr><td>
+<a href="https://www.example.com/cta/19" style="max-width: 437px; line-height: 139%; background-color: #79d8c1">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m20" width="100%"><tbody>
+<tr><td class="r20" style="font-family: Helvetica, Arial, sans-serif; padding: 1px 29px">
+<h2 style="color: #624007; width: 38%">Section 21: what shipped this month</h2>
+<p>Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d5" style="letter-spacing: 0.6px; line-height: 133%">
+<img src="https://cdn.example.com/img/thumb-20-0.png" alt="" width="180">
+<h3 style="width: 85%; font-weight: bold; width: 53%">Item 1</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/20/0">Read more</a>
+</td>
+<td class="d6">
+<img src="https://cdn.example.com/img/thumb-20-1.png" alt="" width="180">
+<h3 style="text-align: center; text-decoration: none; text-decoration: none; font-family: Verdana, Geneva, sans-serif; border-radius: 4px">Item 2</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/20/1" style="font-family: Georgia, 'Times New Roman', serif; background-color: #985beb">Read more</a>
+</td>
+<td class="d7">
+<img src="https://cdn.example.com/img/thumb-20-2.png" alt="" style="text-decoration: none; background-color: #1797be; font-family: Georgia, 'Times New Roman', serif; max-width: 618px; background-color: #c12437" width="180">
+<h3 style="font-weight: bold; text-align: center; border: 1px solid #cef49c; padding: 16px 10px; padding: 13px 12px">Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/20/2" style="color: #d5e8d9; text-align: left; text-decoration: none">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation" style="text-align: right; letter-spacing: 0.1px; background-color: #b64822; text-align: center; margin: 29px 21px"><tbody><tr><td>
+<a href="https://www.example.com/cta/20">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m21" width="100%"><tbody>
+<tr><td class="r21" style="border: 1px solid #98e903; max-width: 498px; font-weight: 600; line-height: 121%; background-image: url(https://cdn.example.com/img/hero-190.png)">
+<h2 style="letter-spacing: 0.4px; background-color: #973e23">Section 22: what shipped this month</h2>
+<p style="margin: 17px 20px; border: 1px solid #e6ea26; letter-spacing: 0.6px">Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d6" style="margin: 19px 14px; font-family: Verdana, Geneva, sans-serif; border: 1px solid #834636">
+<img src="https://cdn.example.com/img/thumb-21-0.png" alt="" width="180">
+<h3>Item 1</h3>
+<p style="border-radius: 10px; text-decoration: none; font-family: 'Segoe UI', Roboto, sans-serif; max-width: 524px; text-align: left">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/21/0" style="border-radius: 7px; letter-spacing: 0.8px; font-weight: 600">Read more</a>
+</td>
+<td class="d7">
+<img src="https://cdn.example.com/img/thumb-21-1.png" alt="" width="180">
+<h3 style="font-size: 21px; max-width: 660px; color: #1d1cb2; text-decoration: none; border: 1px solid #b3e75d">Item 2</h3>
+<p style="border: 1px solid #168827; border-radius: 9px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/21/1">Read more</a>
+</td>
+<td class="d8" style="border-radius: 11px; border: 1px solid #4ffcff; line-height: 153%">
+<img src="https://cdn.example.com/img/thumb-21-2.png" alt="" width="180">
+<h3>Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/21/2" style="text-align: right; margin: 21px 11px; width: 54%; color: #6f2406; font-weight: bold">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation"><tbody><tr><td>
+<a href="https://www.example.com/cta/21" style="border: 1px solid #ca16a6; line-height: 110%; line-height: 153%; text-align: left; letter-spacing: 0.3px">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m22" width="100%" style="margin: 6px 10px; background-color: #97f4f2; border: 1px solid #999ed4"><tbody>
+<tr><td class="r22">
+<h2 style="margin: 2px 0px; letter-spacing: 0.2px; background-color: #39d944">Section 23: what shipped this month</h2>
+<p>Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d7">
+<img src="https://cdn.example.com/img/thumb-22-0.png" alt="" style="font-family: Georgia, 'Times New Roman', serif; margin: 11px 23px" width="180">
+<h3>Item 1</h3>
+<p style="font-family: 'Segoe UI', Roboto, sans-serif; margin: 6px 5px; color: #fb4e3e">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/22/0">Read more</a>
+</td>
+<td class="d8">
+<img src="https://cdn.example.com/img/thumb-22-1.png" alt="" width="180">
+<h3>Item 2</h3>
+<p style="border: 1px solid #f73e51; font-size: 22px; max-width: 323px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/22/1">Read more</a>
+</td>
+<td class="d9" style="text-align: center; width: 26%; margin: 25px 14px">
+<img src="https://cdn.example.com/img/thumb-22-2.png" alt="" width="180">
+<h3>Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/22/2" style="border: 1px solid #09e076; border-radius: 9px">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation"><tbody><tr><td>
+<a href="https://www.example.com/cta/22" style="font-size: 13px; font-family: Georgia, 'Times New Roman', serif; width: 74%; letter-spacing: 0.7px; font-family: Georgia, 'Times New Roman', serif">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m23" width="100%" style="border: 1px solid #64e08d; max-width: 340px; color: #30e734; font-family: 'Segoe UI', Roboto, sans-serif; font-size: 14px"><tbody>
+<tr><td class="r23" style="line-height: 114%; font-weight: 300; color: #06d9c7; border-radius: 6px">
+<h2>Section 24: what shipped this month</h2>
+<p style="background-color: #1d32f6; font-weight: 600; color: #f37b15">Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d8">
+<img src="https://cdn.example.com/img/thumb-23-0.png" alt="" style="width: 40%; text-align: right" width="180">
+<h3 style="max-width: 674px; text-decoration: underline; background-color: #e258ee; text-align: right; line-height: 145%">Item 1</h3>
+<p style="background-color: #6b2a22; padding: 24px 12px; border-radius: 11px; font-size: 26px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/23/0">Read more</a>
+</td>
+<td class="d9">
+<img src="https://cdn.example.com/img/thumb-23-1.png" alt="" style="max-width: 529px; font-size: 20px; background-color: #70f41d" width="180">
+<h3>Item 2</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/23/1">Read more</a>
+</td>
+<td class="d10">
+<img src="https://cdn.example.com/img/thumb-23-2.png" alt="" style="background-color: #ec0a7b; text-align: center; border-radius: 5px; border: 1px solid #9f154d" width="180">
+<h3 style="font-weight: 600; border: 1px solid #eee47b; font-weight: 300">Item 3</h3>
+<p style="font-weight: normal; border: 1px solid #5c99cc; border-radius: 3px">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/23/2" style="border: 1px solid #0134dc; border: 1px solid #d42d30; max-width: 464px">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation"><tbody><tr><td style="letter-spacing: 0.3px; background-color: #d56ad9; background-color: #23f12a; max-width: 313px; color: #edf56f">
+<a href="https://www.example.com/cta/23">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m24" width="100%"><tbody>
+<tr><td class="r24">
+<h2>Section 25: what shipped this month</h2>
+<p>Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%"><tbody><tr>
+<td class="d9" style="border-radius: 0px; margin: 8px 6px; font-family: Georgia, 'Times New Roman', serif">
+<img src="https://cdn.example.com/img/thumb-24-0.png" alt="" width="180">
+<h3>Item 1</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/24/0" style="background-color: #085eae; border: 1px solid #8b8319; border: 1px solid #6d4060; padding: 26px 8px; padding: 17px 13px">Read more</a>
+</td>
+<td class="d10">
+<img src="https://cdn.example.com/img/thumb-24-1.png" alt="" width="180">
+<h3 style="font-size: 17px; text-decoration: none; max-width: 479px">Item 2</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/24/1">Read more</a>
+</td>
+<td class="d11" style="background-color: #cae1a3; font-family: Verdana, Geneva, sans-serif">
+<img src="https://cdn.example.com/img/thumb-24-2.png" alt="" width="180">
+<h3>Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/24/2" style="text-decoration: none; border-radius: 2px; text-decoration: none">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation"><tbody><tr><td>
+<a href="https://www.example.com/cta/24" style="padding: 16px 14px; text-align: right; padding: 21px 4px; color: #f5c59b; line-height: 187%">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" class="m25" width="100%"><tbody>
+<tr><td class="r0">
+<h2>Section 26: what shipped this month</h2>
+<p>Release notes, migration guidance and a short summary of the work landed by the team during this cycle.</p>
+<table role="presentation" width="100%" style="font-size: 25px; font-family: Georgia, 'Times New Roman', serif; border: 1px solid #4cff7b; text-decoration: none; border: 1px solid #4611b3"><tbody><tr>
+<td class="d10" style="font-size: 19px; font-size: 31px; border-radius: 5px; border-radius: 0px; line-height: 171%">
+<img src="https://cdn.example.com/img/thumb-25-0.png" alt="" style="padding: 27px 21px; padding: 5px 16px" width="180">
+<h3>Item 1</h3>
+<p style="font-family: 'Segoe UI', Roboto, sans-serif; text-decoration: underline">A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/25/0">Read more</a>
+</td>
+<td class="d11" style="letter-spacing: 0.8px; border: 1px solid #1fa1b6; font-size: 13px; max-width: 433px; width: 30%; background-image: url(https://cdn.example.com/img/hero-700.png)">
+<img src="https://cdn.example.com/img/thumb-25-1.png" alt="" style="padding: 26px 4px; background-color: #853042; padding: 9px 7px; max-width: 606px" width="180">
+<h3 style="margin: 0px 19px; text-decoration: underline; border-radius: 9px; padding: 8px 26px">Item 2</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/25/1" style="line-height: 142%; color: #aacaa1">Read more</a>
+</td>
+<td class="d12" style="line-height: 179%; background-color: #08f099; font-family: Verdana, Geneva, sans-serif">
+<img src="https://cdn.example.com/img/thumb-25-2.png" alt="" style="background-color: #c0b97f; background-color: #eb1838; border-radius: 6px; margin: 17px 13px; font-weight: bold" width="180">
+<h3 style="font-size: 17px; text-align: right">Item 3</h3>
+<p>A short paragraph describing the item, its status and who to contact.</p>
+<a href="https://www.example.com/read/25/2" style="letter-spacing: 0.1px; background-color: #7ea61b; background-color: #1ef60f">Read more</a>
+</td>
+</tr></tbody></table>
+<table role="presentation"><tbody><tr><td>
+<a href="https://www.example.com/cta/25">View the full changelog</a>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+<table role="presentation" width="100%"><tbody><tr><td style="border: 1px solid #bf8cb7; border-radius: 7px; font-family: Helvetica, Arial, sans-serif">
+<p style="font-size: 30px; font-weight: 300; border-radius: 1px; font-size: 29px">You are receiving this because you subscribed. <a href="https://www.example.com/unsub" style="font-family: Helvetica, Arial, sans-serif; padding: 19px 31px; font-family: 'Segoe UI', Roboto, sans-serif; letter-spacing: 0.4px">Unsubscribe</a>.</p>
+</td></tr></tbody></table>
+</td></tr></tbody></table>
+</center>
+</body>
+</html>


### PR DESCRIPTION
# Added a CSS-heavy benchmark

Cherry picked from #639 without any optimizations to code

The existing benchmarks barely exercise CSS:

* `ecmascript.html`: no styled elements
* `google.html`: only 8 styled elements

CSS sanitization is relatively expensive, so a generated `email.html` benchmark was added to represent HTML email, where inline styles are common.

| Method                        | Mean      | Allocated |
|------------------------------|----------:|----------:|
| SanitizeGoogle               | 6.896 ms  | 6.02 MB   |
| SanitizeEmail                | 22.486 ms | 15.71 MB  |
| SanitizeEmailWithStyleSheets | 24.147 ms | 16.89 MB  |



Despite being much smaller than `google.html`, the email benchmark takes roughly **3× longer** and allocates over **2× as much**, showing how expensive the CSS path can be.

Two benchmarks are included:

* `SanitizeEmail` — normal inline-style sanitization
* `SanitizeEmailWithStyleSheets` — also enables `<style>` so stylesheet sanitization is measured